### PR TITLE
Precarious test coverage

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -188,6 +188,20 @@
       <version>1.0.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.core</artifactId>
+      <version>0.8.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>0.8.13</version>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -283,6 +297,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>com.marvinformatics</groupId>
         <artifactId>docker-compose-maven-plugin</artifactId>
@@ -364,6 +379,17 @@
             <configuration>
               <includeGroupIds>com.datasqrl.flinkrunner</includeGroupIds>
               <includeArtifactIds>system-functions-discovery</includeArtifactIds>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-jacoco-cli</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <includeArtifactIds>org.jacoco.agent</includeArtifactIds>
               <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
           </execution>

--- a/flink-sql-runner/src/main/docker/docker-compose.yml
+++ b/flink-sql-runner/src/main/docker/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       - ./test-classes/datasources/:/datasources/
       - /tmp:/tmp
       - ./test-classes/systemfunction/system-functions-sample-${project.version}.jar:/opt/flink/lib/systemfunction.jar
+      - ./org.jacoco.agent-0.8.13-runtime.jar:/opt/flink/lib/jacoco.agent.jar
+      - ./jacoco.job.exec:/opt/flink/jacoco.exec
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8081/ || exit 1"]
       interval: 1s
@@ -100,6 +102,7 @@ services:
       - ./test-classes/datasources/:/datasources/
       - /tmp:/tmp
       - ./test-classes/systemfunction/system-functions-sample-${project.version}.jar:/opt/flink/lib/systemfunction.jar
+      - ./org.jacoco.agent-0.8.13-runtime.jar:/opt/flink/lib/jacoco.agent.jar
     restart: always
     deploy:
       resources:

--- a/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
@@ -29,6 +29,11 @@ import com.nextbreakpoint.flink.client.model.JobStatus;
 import com.nextbreakpoint.flink.client.model.TerminationMode;
 import com.nextbreakpoint.flink.client.model.UploadStatus;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -45,6 +50,8 @@ import lombok.SneakyThrows;
 import org.apache.flink.shaded.curator5.com.google.common.base.Objects;
 import org.apache.flink.shaded.curator5.com.google.common.collect.Lists;
 import org.awaitility.core.ThrowingRunnable;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.SqlLogger;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -243,11 +250,36 @@ class FlinkMainIT extends AbstractITSupport {
     return restoreAndExecute(null, arguments);
   }
 
+  private int instrument(final File src, final File dest) throws IOException {
+    if (dest.exists()) {
+      return 0;
+    }
+    var instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
+
+    dest.getParentFile().mkdirs();
+    final InputStream input = new FileInputStream(src);
+    try {
+      final OutputStream output = new FileOutputStream(dest);
+      try {
+        return instrumenter.instrumentAll(input, output, src.getAbsolutePath());
+      } finally {
+        output.close();
+      }
+    } catch (final IOException e) {
+      dest.delete();
+      throw e;
+    } finally {
+      input.close();
+    }
+  }
+
   @SneakyThrows
   JarRunResponseBody restoreAndExecute(String savepointPath, String... arguments) {
-    var jarFile = new File("target/flink-sql-runner.uber.jar");
+    var originalFile = new File("target/flink-sql-runner.uber.jar");
+    var instrumentedJarFile = new File("target/flink-sql-runner.jacoco.jar");
+    instrument(originalFile, instrumentedJarFile);
 
-    var uploadResponse = client.uploadJar(jarFile);
+    var uploadResponse = client.uploadJar(instrumentedJarFile);
 
     assertThat(uploadResponse.getStatus()).isEqualTo(UploadStatus.SUCCESS);
 

--- a/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
@@ -258,13 +258,11 @@ class FlinkMainIT extends AbstractITSupport {
 
     dest.getParentFile().mkdirs();
     try (final InputStream input = new FileInputStream(src);
-         final OutputStream output = new FileOutputStream(dest)) {
+        final OutputStream output = new FileOutputStream(dest)) {
       return instrumenter.instrumentAll(input, output, src.getAbsolutePath());
     } catch (final IOException e) {
       dest.delete();
       throw e;
-    } finally {
-      input.close();
     }
   }
 

--- a/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/FlinkMainIT.java
@@ -257,14 +257,9 @@ class FlinkMainIT extends AbstractITSupport {
     var instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
 
     dest.getParentFile().mkdirs();
-    final InputStream input = new FileInputStream(src);
-    try {
-      final OutputStream output = new FileOutputStream(dest);
-      try {
-        return instrumenter.instrumentAll(input, output, src.getAbsolutePath());
-      } finally {
-        output.close();
-      }
+    try (final InputStream input = new FileInputStream(src);
+         final OutputStream output = new FileOutputStream(dest)) {
+      return instrumenter.instrumentAll(input, output, src.getAbsolutePath());
     } catch (final IOException e) {
       dest.delete();
       throw e;

--- a/flink-sql-runner/src/test/java/com/datasqrl/TouchTest.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/TouchTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2024 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TouchTest {
+
+  @BeforeAll
+  static void copyJacocoReports() throws Exception {
+    Files.createFile(Path.of("target/jacoco.job.exec"));
+    Files.setPosixFilePermissions(
+        Path.of("target/jacoco.job.exec"), EnumSet.allOf(PosixFilePermission.class));
+  }
+
+  @Test
+  void doNothing() {}
+}

--- a/testing/coverage/pom.xml
+++ b/testing/coverage/pom.xml
@@ -58,6 +58,8 @@
               <dataFileIncludes>
                 <dataFileInclude>**/jacoco.exec</dataFileInclude>
                 <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
+                <dataFileInclude>**/jacoco.task.exec</dataFileInclude>
+                <dataFileInclude>**/jacoco.job.exec</dataFileInclude>
               </dataFileIncludes>
             </configuration>
           </execution>


### PR DESCRIPTION
Managed to instrument our jar so we can extract test coverage from FlinkMainIT

As is, this is unmaintainable, FlinkMainIT depends on TouchTest running to create a accessible jacoco.exec seed

And the configuration is spread across all the files on this PR.

Bettet than nothing, but very fragile.