### PR TITLE
Return `FlinkVectorType` as a result in `vector_embed` in the OpenAI lib

### DIFF
--- a/functions/openai-functions/pom.xml
+++ b/functions/openai-functions/pom.xml
@@ -41,6 +41,12 @@
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>vector-type</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/functions/openai-functions/src/main/java/com/datasqrl/flinkrunner/stdlib/openai/OpenAIEmbeddings.java
+++ b/functions/openai-functions/src/main/java/com/datasqrl/flinkrunner/stdlib/openai/OpenAIEmbeddings.java
@@ -17,6 +17,7 @@ package com.datasqrl.flinkrunner.stdlib.openai;
 
 import static com.datasqrl.flinkrunner.stdlib.openai.OpenAIUtil.*;
 
+import com.datasqrl.flinkrunner.types.vector.FlinkVectorType;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -37,14 +38,14 @@ public class OpenAIEmbeddings {
   private final HttpClient httpClient;
 
   public OpenAIEmbeddings() {
-    this.httpClient = HttpClient.newHttpClient();
+    this(HttpClient.newHttpClient());
   }
 
   public OpenAIEmbeddings(HttpClient httpClient) {
     this.httpClient = httpClient;
   }
 
-  public double[] vectorEmbed(String text, String modelName)
+  public FlinkVectorType vectorEmbed(String text, String modelName)
       throws IOException, InterruptedException {
     if (text == null || modelName == null) {
       return null;
@@ -53,7 +54,7 @@ public class OpenAIEmbeddings {
     return vectorEmbed(text, modelName, TOKEN_LIMIT);
   }
 
-  public double[] vectorEmbed(String text, String modelName, int tokenLimit)
+  public FlinkVectorType vectorEmbed(String text, String modelName, int tokenLimit)
       throws IOException, InterruptedException {
     // Truncate text to fit the maximum token limit
     text = truncateText(text, tokenLimit);
@@ -85,7 +86,7 @@ public class OpenAIEmbeddings {
     }
   }
 
-  private double[] parseEmbeddingVector(String responseBody) throws IOException {
+  private FlinkVectorType parseEmbeddingVector(String responseBody) throws IOException {
     // Parse JSON response
     JsonNode jsonResponse = objectMapper.readTree(responseBody);
     ArrayNode embeddingArray = (ArrayNode) jsonResponse.get("data").get(0).get("embedding");
@@ -95,7 +96,7 @@ public class OpenAIEmbeddings {
     for (int i = 0; i < embeddingArray.size(); i++) {
       embeddingVector[i] = embeddingArray.get(i).asDouble();
     }
-    return embeddingVector;
+    return new FlinkVectorType(embeddingVector);
   }
 
   // Method to truncate the text if it exceeds the token limit (adjust as needed)

--- a/functions/openai-functions/src/main/java/com/datasqrl/flinkrunner/stdlib/openai/vector_embed.java
+++ b/functions/openai-functions/src/main/java/com/datasqrl/flinkrunner/stdlib/openai/vector_embed.java
@@ -16,6 +16,7 @@
 package com.datasqrl.flinkrunner.stdlib.openai;
 
 import com.datasqrl.flinkrunner.stdlib.openai.util.FunctionMetricTracker;
+import com.datasqrl.flinkrunner.types.vector.FlinkVectorType;
 import com.google.auto.service.AutoService;
 import java.util.concurrent.CompletableFuture;
 import org.apache.flink.table.functions.AsyncScalarFunction;
@@ -42,7 +43,7 @@ public class vector_embed extends AsyncScalarFunction {
     return new FunctionMetricTracker(context, functionName);
   }
 
-  public void eval(CompletableFuture<double[]> result, String text, String modelName) {
+  public void eval(CompletableFuture<FlinkVectorType> result, String text, String modelName) {
     executor
         .executeAsync(() -> openAIEmbeddings.vectorEmbed(text, modelName))
         .thenAccept(result::complete)


### PR DESCRIPTION
For the sake of completeness in the current structure this requires a `openai-functions` to depend on `vector-type`, as `FlinkVectorType` is defined in the latter. That is not a problem, cause both will be part of the uber JAR, hence I incloded it with a `provided` scope.

Relevant examples PR: https://github.com/DataSQRL/datasqrl-examples/pull/62

### TODO
- [x] This should be reflected in the relevant example in the [datasqrl-examples](https://github.com/DataSQRL/datasqrl-examples) repo.