### PR TITLE
Use `spotless-maven-plugin` to format Java and `pom.xml` files

### DIFF
--- a/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeDynamicKafkaDeserializationSchema.java
+++ b/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeDynamicKafkaDeserializationSchema.java
@@ -15,48 +15,50 @@
  */
 package org.apache.flink.streaming.connectors.kafka.table;
 
-import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
-import javax.annotation.Nullable;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
+
+import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import javax.annotation.Nullable;
 
 /** A specific {@link KafkaSerializationSchema} for {@link SafeKafkaDynamicSource}. */
 public class SafeDynamicKafkaDeserializationSchema extends DynamicKafkaDeserializationSchema {
 
-  private final DeserFailureHandler deserFailureHandler;
+    private final DeserFailureHandler deserFailureHandler;
 
-  SafeDynamicKafkaDeserializationSchema(
-      int physicalArity,
-      @Nullable DeserializationSchema<RowData> keyDeserialization,
-      int[] keyProjection,
-      DeserializationSchema<RowData> valueDeserialization,
-      int[] valueProjection,
-      boolean hasMetadata,
-      MetadataConverter[] metadataConverters,
-      TypeInformation<RowData> producedTypeInfo,
-      boolean upsertMode,
-      DeserFailureHandler deserFailureHandler) {
-    super(
-        physicalArity,
-        keyDeserialization,
-        keyProjection,
-        valueDeserialization,
-        valueProjection,
-        hasMetadata,
-        metadataConverters,
-        producedTypeInfo,
-        upsertMode);
-    this.deserFailureHandler = deserFailureHandler;
-  }
+    SafeDynamicKafkaDeserializationSchema(
+            int physicalArity,
+            @Nullable DeserializationSchema<RowData> keyDeserialization,
+            int[] keyProjection,
+            DeserializationSchema<RowData> valueDeserialization,
+            int[] valueProjection,
+            boolean hasMetadata,
+            MetadataConverter[] metadataConverters,
+            TypeInformation<RowData> producedTypeInfo,
+            boolean upsertMode,
+            DeserFailureHandler deserFailureHandler) {
+        super(
+                physicalArity,
+                keyDeserialization,
+                keyProjection,
+                valueDeserialization,
+                valueProjection,
+                hasMetadata,
+                metadataConverters,
+                producedTypeInfo,
+                upsertMode);
+        this.deserFailureHandler = deserFailureHandler;
+    }
 
-  @Override
-  public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<RowData> collector)
-      throws Exception {
-    deserFailureHandler.deserWithFailureHandling(
-        record, () -> super.deserialize(record, collector));
-  }
+    @Override
+    public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<RowData> collector)
+            throws Exception {
+        deserFailureHandler.deserWithFailureHandling(
+                record, () -> super.deserialize(record, collector));
+    }
 }

--- a/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeKafkaDynamicSource.java
+++ b/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeKafkaDynamicSource.java
@@ -15,22 +15,6 @@
  */
 package org.apache.flink.streaming.connectors.kafka.table;
 
-import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -66,596 +50,633 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
+
+import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 /** A version-agnostic Kafka {@link ScanTableSource}. */
 @Internal
 public class SafeKafkaDynamicSource
-    implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+        implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
 
-  private static final String KAFKA_TRANSFORMATION = "kafka";
+    private static final String KAFKA_TRANSFORMATION = "kafka";
 
-  // --------------------------------------------------------------------------------------------
-  // Mutable attributes
-  // --------------------------------------------------------------------------------------------
-
-  /** Data type that describes the final output of the source. */
-  protected DataType producedDataType;
-
-  /** Metadata that is appended at the end of a physical source row. */
-  protected List<String> metadataKeys;
-
-  /** Watermark strategy that is used to generate per-partition watermark. */
-  protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
-
-  // --------------------------------------------------------------------------------------------
-  // Format attributes
-  // --------------------------------------------------------------------------------------------
-
-  private static final String VALUE_METADATA_PREFIX = "value.";
-
-  /** Data type to configure the formats. */
-  protected final DataType physicalDataType;
-
-  /** Optional format for decoding keys from Kafka. */
-  protected final @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat;
-
-  /** Format for decoding values from Kafka. */
-  protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
-
-  /** Indices that determine the key fields and the target position in the produced row. */
-  protected final int[] keyProjection;
-
-  /** Indices that determine the value fields and the target position in the produced row. */
-  protected final int[] valueProjection;
-
-  /** Prefix that needs to be removed from fields when constructing the physical data type. */
-  protected final @Nullable String keyPrefix;
-
-  // --------------------------------------------------------------------------------------------
-  // Kafka-specific attributes
-  // --------------------------------------------------------------------------------------------
-
-  /** The Kafka topics to consume. */
-  protected final List<String> topics;
-
-  /** The Kafka topic pattern to consume. */
-  protected final Pattern topicPattern;
-
-  /** Properties for the Kafka consumer. */
-  protected final Properties properties;
-
-  /** The startup mode for the contained consumer (default is {@link StartupMode#GROUP_OFFSETS}). */
-  protected final StartupMode startupMode;
-
-  /**
-   * Specific startup offsets; only relevant when startup mode is {@link
-   * StartupMode#SPECIFIC_OFFSETS}.
-   */
-  protected final Map<KafkaTopicPartition, Long> specificStartupOffsets;
-
-  /**
-   * The start timestamp to locate partition offsets; only relevant when startup mode is {@link
-   * StartupMode#TIMESTAMP}.
-   */
-  protected final long startupTimestampMillis;
-
-  /** The bounded mode for the contained consumer (default is an unbounded data stream). */
-  protected final BoundedMode boundedMode;
-
-  /**
-   * Specific end offsets; only relevant when bounded mode is {@link BoundedMode#SPECIFIC_OFFSETS}.
-   */
-  protected final Map<KafkaTopicPartition, Long> specificBoundedOffsets;
-
-  /**
-   * The bounded timestamp to locate partition offsets; only relevant when bounded mode is {@link
-   * BoundedMode#TIMESTAMP}.
-   */
-  protected final long boundedTimestampMillis;
-
-  /** Flag to determine source mode. In upsert mode, it will keep the tombstone message. * */
-  protected final boolean upsertMode;
-
-  protected final String tableIdentifier;
-
-  protected final DeserFailureHandler deserFailureHandler;
-
-  public SafeKafkaDynamicSource(
-      DataType physicalDataType,
-      @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
-      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
-      int[] keyProjection,
-      int[] valueProjection,
-      @Nullable String keyPrefix,
-      @Nullable List<String> topics,
-      @Nullable Pattern topicPattern,
-      Properties properties,
-      StartupMode startupMode,
-      Map<KafkaTopicPartition, Long> specificStartupOffsets,
-      long startupTimestampMillis,
-      BoundedMode boundedMode,
-      Map<KafkaTopicPartition, Long> specificBoundedOffsets,
-      long boundedTimestampMillis,
-      boolean upsertMode,
-      String tableIdentifier,
-      DeserFailureHandler deserFailureHandler) {
-    // Format attributes
-    this.physicalDataType =
-        Preconditions.checkNotNull(physicalDataType, "Physical data type must not be null.");
-    this.keyDecodingFormat = keyDecodingFormat;
-    this.valueDecodingFormat =
-        Preconditions.checkNotNull(valueDecodingFormat, "Value decoding format must not be null.");
-    this.keyProjection =
-        Preconditions.checkNotNull(keyProjection, "Key projection must not be null.");
-    this.valueProjection =
-        Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
-    this.keyPrefix = keyPrefix;
+    // --------------------------------------------------------------------------------------------
     // Mutable attributes
-    this.producedDataType = physicalDataType;
-    this.metadataKeys = Collections.emptyList();
-    this.watermarkStrategy = null;
+    // --------------------------------------------------------------------------------------------
+
+    /** Data type that describes the final output of the source. */
+    protected DataType producedDataType;
+
+    /** Metadata that is appended at the end of a physical source row. */
+    protected List<String> metadataKeys;
+
+    /** Watermark strategy that is used to generate per-partition watermark. */
+    protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
+
+    // --------------------------------------------------------------------------------------------
+    // Format attributes
+    // --------------------------------------------------------------------------------------------
+
+    private static final String VALUE_METADATA_PREFIX = "value.";
+
+    /** Data type to configure the formats. */
+    protected final DataType physicalDataType;
+
+    /** Optional format for decoding keys from Kafka. */
+    protected final @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat;
+
+    /** Format for decoding values from Kafka. */
+    protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
+
+    /** Indices that determine the key fields and the target position in the produced row. */
+    protected final int[] keyProjection;
+
+    /** Indices that determine the value fields and the target position in the produced row. */
+    protected final int[] valueProjection;
+
+    /** Prefix that needs to be removed from fields when constructing the physical data type. */
+    protected final @Nullable String keyPrefix;
+
+    // --------------------------------------------------------------------------------------------
     // Kafka-specific attributes
-    Preconditions.checkArgument(
-        (topics != null && topicPattern == null) || (topics == null && topicPattern != null),
-        "Either Topic or Topic Pattern must be set for source.");
-    this.topics = topics;
-    this.topicPattern = topicPattern;
-    this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
-    this.startupMode = Preconditions.checkNotNull(startupMode, "Startup mode must not be null.");
-    this.specificStartupOffsets =
-        Preconditions.checkNotNull(specificStartupOffsets, "Specific offsets must not be null.");
-    this.startupTimestampMillis = startupTimestampMillis;
-    this.boundedMode = Preconditions.checkNotNull(boundedMode, "Bounded mode must not be null.");
-    this.specificBoundedOffsets =
-        Preconditions.checkNotNull(
-            specificBoundedOffsets, "Specific bounded offsets must not be null.");
-    this.boundedTimestampMillis = boundedTimestampMillis;
-    this.upsertMode = upsertMode;
-    this.tableIdentifier = tableIdentifier;
-    this.deserFailureHandler = deserFailureHandler;
-  }
+    // --------------------------------------------------------------------------------------------
 
-  @Override
-  public ChangelogMode getChangelogMode() {
-    return valueDecodingFormat.getChangelogMode();
-  }
+    /** The Kafka topics to consume. */
+    protected final List<String> topics;
 
-  @Override
-  public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
-    final DeserializationSchema<RowData> keyDeserialization =
-        createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+    /** The Kafka topic pattern to consume. */
+    protected final Pattern topicPattern;
 
-    final DeserializationSchema<RowData> valueDeserialization =
-        createDeserialization(context, valueDecodingFormat, valueProjection, null);
+    /** Properties for the Kafka consumer. */
+    protected final Properties properties;
 
-    final TypeInformation<RowData> producedTypeInfo =
-        context.createTypeInformation(producedDataType);
+    /**
+     * The startup mode for the contained consumer (default is {@link StartupMode#GROUP_OFFSETS}).
+     */
+    protected final StartupMode startupMode;
 
-    final KafkaSource<RowData> kafkaSource =
-        createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
+    /**
+     * Specific startup offsets; only relevant when startup mode is {@link
+     * StartupMode#SPECIFIC_OFFSETS}.
+     */
+    protected final Map<KafkaTopicPartition, Long> specificStartupOffsets;
 
-    return new DataStreamScanProvider() {
-      @Override
-      public DataStream<RowData> produceDataStream(
-          ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
-        if (watermarkStrategy == null) {
-          watermarkStrategy = WatermarkStrategy.noWatermarks();
-        }
-        DataStreamSource<RowData> sourceStream =
-            execEnv.fromSource(kafkaSource, watermarkStrategy, "KafkaSource-" + tableIdentifier);
-        providerContext.generateUid(KAFKA_TRANSFORMATION).ifPresent(sourceStream::uid);
-        return sourceStream;
-      }
+    /**
+     * The start timestamp to locate partition offsets; only relevant when startup mode is {@link
+     * StartupMode#TIMESTAMP}.
+     */
+    protected final long startupTimestampMillis;
 
-      @Override
-      public boolean isBounded() {
-        return kafkaSource.getBoundedness() == Boundedness.BOUNDED;
-      }
-    };
-  }
+    /** The bounded mode for the contained consumer (default is an unbounded data stream). */
+    protected final BoundedMode boundedMode;
 
-  @Override
-  public Map<String, DataType> listReadableMetadata() {
-    final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+    /**
+     * Specific end offsets; only relevant when bounded mode is {@link
+     * BoundedMode#SPECIFIC_OFFSETS}.
+     */
+    protected final Map<KafkaTopicPartition, Long> specificBoundedOffsets;
 
-    // according to convention, the order of the final row must be
-    // PHYSICAL + FORMAT METADATA + CONNECTOR METADATA
-    // where the format metadata has highest precedence
+    /**
+     * The bounded timestamp to locate partition offsets; only relevant when bounded mode is {@link
+     * BoundedMode#TIMESTAMP}.
+     */
+    protected final long boundedTimestampMillis;
 
-    // add value format metadata with prefix
-    valueDecodingFormat
-        .listReadableMetadata()
-        .forEach((key, value) -> metadataMap.put(VALUE_METADATA_PREFIX + key, value));
+    /** Flag to determine source mode. In upsert mode, it will keep the tombstone message. * */
+    protected final boolean upsertMode;
 
-    // add connector metadata
-    Stream.of(ReadableMetadata.values())
-        .forEachOrdered(m -> metadataMap.putIfAbsent(m.key, m.dataType));
+    protected final String tableIdentifier;
 
-    return metadataMap;
-  }
+    protected final DeserFailureHandler deserFailureHandler;
 
-  @Override
-  public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-    // separate connector and format metadata
-    final List<String> formatMetadataKeys =
-        metadataKeys.stream()
-            .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
-            .collect(Collectors.toList());
-    final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
-    connectorMetadataKeys.removeAll(formatMetadataKeys);
-
-    // push down format metadata
-    final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
-    if (formatMetadata.size() > 0) {
-      final List<String> requestedFormatMetadataKeys =
-          formatMetadataKeys.stream()
-              .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
-              .collect(Collectors.toList());
-      valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+    public SafeKafkaDynamicSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<KafkaTopicPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis,
+            BoundedMode boundedMode,
+            Map<KafkaTopicPartition, Long> specificBoundedOffsets,
+            long boundedTimestampMillis,
+            boolean upsertMode,
+            String tableIdentifier,
+            DeserFailureHandler deserFailureHandler) {
+        // Format attributes
+        this.physicalDataType =
+                Preconditions.checkNotNull(
+                        physicalDataType, "Physical data type must not be null.");
+        this.keyDecodingFormat = keyDecodingFormat;
+        this.valueDecodingFormat =
+                Preconditions.checkNotNull(
+                        valueDecodingFormat, "Value decoding format must not be null.");
+        this.keyProjection =
+                Preconditions.checkNotNull(keyProjection, "Key projection must not be null.");
+        this.valueProjection =
+                Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
+        this.keyPrefix = keyPrefix;
+        // Mutable attributes
+        this.producedDataType = physicalDataType;
+        this.metadataKeys = Collections.emptyList();
+        this.watermarkStrategy = null;
+        // Kafka-specific attributes
+        Preconditions.checkArgument(
+                (topics != null && topicPattern == null)
+                        || (topics == null && topicPattern != null),
+                "Either Topic or Topic Pattern must be set for source.");
+        this.topics = topics;
+        this.topicPattern = topicPattern;
+        this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
+        this.startupMode =
+                Preconditions.checkNotNull(startupMode, "Startup mode must not be null.");
+        this.specificStartupOffsets =
+                Preconditions.checkNotNull(
+                        specificStartupOffsets, "Specific offsets must not be null.");
+        this.startupTimestampMillis = startupTimestampMillis;
+        this.boundedMode =
+                Preconditions.checkNotNull(boundedMode, "Bounded mode must not be null.");
+        this.specificBoundedOffsets =
+                Preconditions.checkNotNull(
+                        specificBoundedOffsets, "Specific bounded offsets must not be null.");
+        this.boundedTimestampMillis = boundedTimestampMillis;
+        this.upsertMode = upsertMode;
+        this.tableIdentifier = tableIdentifier;
+        this.deserFailureHandler = deserFailureHandler;
     }
 
-    this.metadataKeys = connectorMetadataKeys;
-    this.producedDataType = producedDataType;
-  }
-
-  @Override
-  public boolean supportsMetadataProjection() {
-    return false;
-  }
-
-  @Override
-  public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
-    this.watermarkStrategy = watermarkStrategy;
-  }
-
-  @Override
-  public DynamicTableSource copy() {
-    final SafeKafkaDynamicSource copy =
-        new SafeKafkaDynamicSource(
-            physicalDataType,
-            keyDecodingFormat,
-            valueDecodingFormat,
-            keyProjection,
-            valueProjection,
-            keyPrefix,
-            topics,
-            topicPattern,
-            properties,
-            startupMode,
-            specificStartupOffsets,
-            startupTimestampMillis,
-            boundedMode,
-            specificBoundedOffsets,
-            boundedTimestampMillis,
-            upsertMode,
-            tableIdentifier,
-            deserFailureHandler);
-    copy.producedDataType = producedDataType;
-    copy.metadataKeys = metadataKeys;
-    copy.watermarkStrategy = watermarkStrategy;
-    return copy;
-  }
-
-  @Override
-  public String asSummaryString() {
-    return "Kafka table source";
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final SafeKafkaDynamicSource that = (SafeKafkaDynamicSource) o;
-    return Objects.equals(producedDataType, that.producedDataType)
-        && Objects.equals(metadataKeys, that.metadataKeys)
-        && Objects.equals(physicalDataType, that.physicalDataType)
-        && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
-        && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
-        && Arrays.equals(keyProjection, that.keyProjection)
-        && Arrays.equals(valueProjection, that.valueProjection)
-        && Objects.equals(keyPrefix, that.keyPrefix)
-        && Objects.equals(topics, that.topics)
-        && Objects.equals(String.valueOf(topicPattern), String.valueOf(that.topicPattern))
-        && Objects.equals(properties, that.properties)
-        && startupMode == that.startupMode
-        && Objects.equals(specificStartupOffsets, that.specificStartupOffsets)
-        && startupTimestampMillis == that.startupTimestampMillis
-        && boundedMode == that.boundedMode
-        && Objects.equals(specificBoundedOffsets, that.specificBoundedOffsets)
-        && boundedTimestampMillis == that.boundedTimestampMillis
-        && Objects.equals(upsertMode, that.upsertMode)
-        && Objects.equals(tableIdentifier, that.tableIdentifier)
-        && Objects.equals(watermarkStrategy, that.watermarkStrategy);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        producedDataType,
-        metadataKeys,
-        physicalDataType,
-        keyDecodingFormat,
-        valueDecodingFormat,
-        Arrays.hashCode(keyProjection),
-        Arrays.hashCode(valueProjection),
-        keyPrefix,
-        topics,
-        topicPattern,
-        properties,
-        startupMode,
-        specificStartupOffsets,
-        startupTimestampMillis,
-        boundedMode,
-        specificBoundedOffsets,
-        boundedTimestampMillis,
-        upsertMode,
-        tableIdentifier,
-        watermarkStrategy);
-  }
-
-  // --------------------------------------------------------------------------------------------
-
-  protected KafkaSource<RowData> createKafkaSource(
-      DeserializationSchema<RowData> keyDeserialization,
-      DeserializationSchema<RowData> valueDeserialization,
-      TypeInformation<RowData> producedTypeInfo) {
-
-    final KafkaDeserializationSchema<RowData> kafkaDeserializer =
-        createKafkaDeserializationSchema(
-            keyDeserialization, valueDeserialization, producedTypeInfo);
-
-    final KafkaSourceBuilder<RowData> kafkaSourceBuilder = KafkaSource.builder();
-
-    if (topics != null) {
-      kafkaSourceBuilder.setTopics(topics);
-    } else {
-      kafkaSourceBuilder.setTopicPattern(topicPattern);
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return valueDecodingFormat.getChangelogMode();
     }
 
-    switch (startupMode) {
-      case EARLIEST:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.earliest());
-        break;
-      case LATEST:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.latest());
-        break;
-      case GROUP_OFFSETS:
-        String offsetResetConfig =
-            properties.getProperty(
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.NONE.name());
-        OffsetResetStrategy offsetResetStrategy = getResetStrategy(offsetResetConfig);
-        kafkaSourceBuilder.setStartingOffsets(
-            OffsetsInitializer.committedOffsets(offsetResetStrategy));
-        break;
-      case SPECIFIC_OFFSETS:
-        Map<TopicPartition, Long> offsets = new HashMap<>();
-        specificStartupOffsets.forEach(
-            (tp, offset) ->
-                offsets.put(new TopicPartition(tp.getTopic(), tp.getPartition()), offset));
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.offsets(offsets));
-        break;
-      case TIMESTAMP:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.timestamp(startupTimestampMillis));
-        break;
-    }
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
+        final DeserializationSchema<RowData> keyDeserialization =
+                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
 
-    switch (boundedMode) {
-      case UNBOUNDED:
-        kafkaSourceBuilder.setUnbounded(new NoStoppingOffsetsInitializer());
-        break;
-      case LATEST:
-        kafkaSourceBuilder.setBounded(OffsetsInitializer.latest());
-        break;
-      case GROUP_OFFSETS:
-        kafkaSourceBuilder.setBounded(OffsetsInitializer.committedOffsets());
-        break;
-      case SPECIFIC_OFFSETS:
-        Map<TopicPartition, Long> offsets = new HashMap<>();
-        specificBoundedOffsets.forEach(
-            (tp, offset) ->
-                offsets.put(new TopicPartition(tp.getTopic(), tp.getPartition()), offset));
-        kafkaSourceBuilder.setBounded(OffsetsInitializer.offsets(offsets));
-        break;
-      case TIMESTAMP:
-        kafkaSourceBuilder.setBounded(OffsetsInitializer.timestamp(boundedTimestampMillis));
-        break;
-    }
+        final DeserializationSchema<RowData> valueDeserialization =
+                createDeserialization(context, valueDecodingFormat, valueProjection, null);
 
-    kafkaSourceBuilder
-        .setProperties(properties)
-        .setDeserializer(KafkaRecordDeserializationSchema.of(kafkaDeserializer));
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
 
-    return kafkaSourceBuilder.build();
-  }
+        final KafkaSource<RowData> kafkaSource =
+                createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
 
-  private OffsetResetStrategy getResetStrategy(String offsetResetConfig) {
-    return Arrays.stream(OffsetResetStrategy.values())
-        .filter(ors -> ors.name().equals(offsetResetConfig.toUpperCase(Locale.ROOT)))
-        .findAny()
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    String.format(
-                        "%s can not be set to %s. Valid values: [%s]",
-                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-                        offsetResetConfig,
-                        Arrays.stream(OffsetResetStrategy.values())
-                            .map(Enum::name)
-                            .map(String::toLowerCase)
-                            .collect(Collectors.joining(",")))));
-  }
-
-  private KafkaDeserializationSchema<RowData> createKafkaDeserializationSchema(
-      DeserializationSchema<RowData> keyDeserialization,
-      DeserializationSchema<RowData> valueDeserialization,
-      TypeInformation<RowData> producedTypeInfo) {
-    final MetadataConverter[] metadataConverters =
-        metadataKeys.stream()
-            .map(
-                k ->
-                    Stream.of(ReadableMetadata.values())
-                        .filter(rm -> rm.key.equals(k))
-                        .findFirst()
-                        .orElseThrow(IllegalStateException::new))
-            .map(m -> m.converter)
-            .toArray(MetadataConverter[]::new);
-
-    // check if connector metadata is used at all
-    final boolean hasMetadata = metadataKeys.size() > 0;
-
-    // adjust physical arity with value format's metadata
-    final int adjustedPhysicalArity =
-        DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
-
-    // adjust value format projection to include value format's metadata columns at the end
-    final int[] adjustedValueProjection =
-        IntStream.concat(
-                IntStream.of(valueProjection),
-                IntStream.range(
-                    keyProjection.length + valueProjection.length, adjustedPhysicalArity))
-            .toArray();
-
-    return new SafeDynamicKafkaDeserializationSchema(
-        adjustedPhysicalArity,
-        keyDeserialization,
-        keyProjection,
-        valueDeserialization,
-        adjustedValueProjection,
-        hasMetadata,
-        metadataConverters,
-        producedTypeInfo,
-        upsertMode,
-        deserFailureHandler);
-  }
-
-  private @Nullable DeserializationSchema<RowData> createDeserialization(
-      DynamicTableSource.Context context,
-      @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-      int[] projection,
-      @Nullable String prefix) {
-    if (format == null) {
-      return null;
-    }
-    DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
-    if (prefix != null) {
-      physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-    }
-    return format.createRuntimeDecoder(context, physicalFormatDataType);
-  }
-
-  // --------------------------------------------------------------------------------------------
-  // Metadata handling
-  // --------------------------------------------------------------------------------------------
-
-  enum ReadableMetadata {
-    TOPIC(
-        "topic",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return StringData.fromString(record.topic());
-          }
-        }),
-
-    PARTITION(
-        "partition",
-        DataTypes.INT().notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return record.partition();
-          }
-        }),
-
-    HEADERS(
-        "headers",
-        // key and value of the map are nullable to make handling easier in queries
-        DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable()).notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            final Map<StringData, byte[]> map = new HashMap<>();
-            for (Header header : record.headers()) {
-              map.put(StringData.fromString(header.key()), header.value());
+        return new DataStreamScanProvider() {
+            @Override
+            public DataStream<RowData> produceDataStream(
+                    ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                if (watermarkStrategy == null) {
+                    watermarkStrategy = WatermarkStrategy.noWatermarks();
+                }
+                DataStreamSource<RowData> sourceStream =
+                        execEnv.fromSource(
+                                kafkaSource, watermarkStrategy, "KafkaSource-" + tableIdentifier);
+                providerContext.generateUid(KAFKA_TRANSFORMATION).ifPresent(sourceStream::uid);
+                return sourceStream;
             }
-            return new GenericMapData(map);
-          }
-        }),
 
-    LEADER_EPOCH(
-        "leader-epoch",
-        DataTypes.INT().nullable(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return record.leaderEpoch().orElse(null);
-          }
-        }),
-
-    OFFSET(
-        "offset",
-        DataTypes.BIGINT().notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return record.offset();
-          }
-        }),
-
-    TIMESTAMP(
-        "timestamp",
-        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return TimestampData.fromEpochMillis(record.timestamp());
-          }
-        }),
-
-    TIMESTAMP_TYPE(
-        "timestamp-type",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Object read(ConsumerRecord<?, ?> record) {
-            return StringData.fromString(record.timestampType().toString());
-          }
-        });
-
-    final String key;
-
-    final DataType dataType;
-
-    final MetadataConverter converter;
-
-    ReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
-      this.key = key;
-      this.dataType = dataType;
-      this.converter = converter;
+            @Override
+            public boolean isBounded() {
+                return kafkaSource.getBoundedness() == Boundedness.BOUNDED;
+            }
+        };
     }
-  }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+
+        // according to convention, the order of the final row must be
+        // PHYSICAL + FORMAT METADATA + CONNECTOR METADATA
+        // where the format metadata has highest precedence
+
+        // add value format metadata with prefix
+        valueDecodingFormat
+                .listReadableMetadata()
+                .forEach((key, value) -> metadataMap.put(VALUE_METADATA_PREFIX + key, value));
+
+        // add connector metadata
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.putIfAbsent(m.key, m.dataType));
+
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // separate connector and format metadata
+        final List<String> formatMetadataKeys =
+                metadataKeys.stream()
+                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
+                        .collect(Collectors.toList());
+        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
+        connectorMetadataKeys.removeAll(formatMetadataKeys);
+
+        // push down format metadata
+        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
+        if (formatMetadata.size() > 0) {
+            final List<String> requestedFormatMetadataKeys =
+                    formatMetadataKeys.stream()
+                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
+                            .collect(Collectors.toList());
+            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        }
+
+        this.metadataKeys = connectorMetadataKeys;
+        this.producedDataType = producedDataType;
+    }
+
+    @Override
+    public boolean supportsMetadataProjection() {
+        return false;
+    }
+
+    @Override
+    public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        final SafeKafkaDynamicSource copy =
+                new SafeKafkaDynamicSource(
+                        physicalDataType,
+                        keyDecodingFormat,
+                        valueDecodingFormat,
+                        keyProjection,
+                        valueProjection,
+                        keyPrefix,
+                        topics,
+                        topicPattern,
+                        properties,
+                        startupMode,
+                        specificStartupOffsets,
+                        startupTimestampMillis,
+                        boundedMode,
+                        specificBoundedOffsets,
+                        boundedTimestampMillis,
+                        upsertMode,
+                        tableIdentifier,
+                        deserFailureHandler);
+        copy.producedDataType = producedDataType;
+        copy.metadataKeys = metadataKeys;
+        copy.watermarkStrategy = watermarkStrategy;
+        return copy;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Kafka table source";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SafeKafkaDynamicSource that = (SafeKafkaDynamicSource) o;
+        return Objects.equals(producedDataType, that.producedDataType)
+                && Objects.equals(metadataKeys, that.metadataKeys)
+                && Objects.equals(physicalDataType, that.physicalDataType)
+                && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
+                && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
+                && Arrays.equals(keyProjection, that.keyProjection)
+                && Arrays.equals(valueProjection, that.valueProjection)
+                && Objects.equals(keyPrefix, that.keyPrefix)
+                && Objects.equals(topics, that.topics)
+                && Objects.equals(String.valueOf(topicPattern), String.valueOf(that.topicPattern))
+                && Objects.equals(properties, that.properties)
+                && startupMode == that.startupMode
+                && Objects.equals(specificStartupOffsets, that.specificStartupOffsets)
+                && startupTimestampMillis == that.startupTimestampMillis
+                && boundedMode == that.boundedMode
+                && Objects.equals(specificBoundedOffsets, that.specificBoundedOffsets)
+                && boundedTimestampMillis == that.boundedTimestampMillis
+                && Objects.equals(upsertMode, that.upsertMode)
+                && Objects.equals(tableIdentifier, that.tableIdentifier)
+                && Objects.equals(watermarkStrategy, that.watermarkStrategy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                producedDataType,
+                metadataKeys,
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                Arrays.hashCode(keyProjection),
+                Arrays.hashCode(valueProjection),
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                boundedMode,
+                specificBoundedOffsets,
+                boundedTimestampMillis,
+                upsertMode,
+                tableIdentifier,
+                watermarkStrategy);
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    protected KafkaSource<RowData> createKafkaSource(
+            DeserializationSchema<RowData> keyDeserialization,
+            DeserializationSchema<RowData> valueDeserialization,
+            TypeInformation<RowData> producedTypeInfo) {
+
+        final KafkaDeserializationSchema<RowData> kafkaDeserializer =
+                createKafkaDeserializationSchema(
+                        keyDeserialization, valueDeserialization, producedTypeInfo);
+
+        final KafkaSourceBuilder<RowData> kafkaSourceBuilder = KafkaSource.builder();
+
+        if (topics != null) {
+            kafkaSourceBuilder.setTopics(topics);
+        } else {
+            kafkaSourceBuilder.setTopicPattern(topicPattern);
+        }
+
+        switch (startupMode) {
+            case EARLIEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.earliest());
+                break;
+            case LATEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.latest());
+                break;
+            case GROUP_OFFSETS:
+                String offsetResetConfig =
+                        properties.getProperty(
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                OffsetResetStrategy.NONE.name());
+                OffsetResetStrategy offsetResetStrategy = getResetStrategy(offsetResetConfig);
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.committedOffsets(offsetResetStrategy));
+                break;
+            case SPECIFIC_OFFSETS:
+                Map<TopicPartition, Long> offsets = new HashMap<>();
+                specificStartupOffsets.forEach(
+                        (tp, offset) ->
+                                offsets.put(
+                                        new TopicPartition(tp.getTopic(), tp.getPartition()),
+                                        offset));
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.offsets(offsets));
+                break;
+            case TIMESTAMP:
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.timestamp(startupTimestampMillis));
+                break;
+        }
+
+        switch (boundedMode) {
+            case UNBOUNDED:
+                kafkaSourceBuilder.setUnbounded(new NoStoppingOffsetsInitializer());
+                break;
+            case LATEST:
+                kafkaSourceBuilder.setBounded(OffsetsInitializer.latest());
+                break;
+            case GROUP_OFFSETS:
+                kafkaSourceBuilder.setBounded(OffsetsInitializer.committedOffsets());
+                break;
+            case SPECIFIC_OFFSETS:
+                Map<TopicPartition, Long> offsets = new HashMap<>();
+                specificBoundedOffsets.forEach(
+                        (tp, offset) ->
+                                offsets.put(
+                                        new TopicPartition(tp.getTopic(), tp.getPartition()),
+                                        offset));
+                kafkaSourceBuilder.setBounded(OffsetsInitializer.offsets(offsets));
+                break;
+            case TIMESTAMP:
+                kafkaSourceBuilder.setBounded(OffsetsInitializer.timestamp(boundedTimestampMillis));
+                break;
+        }
+
+        kafkaSourceBuilder
+                .setProperties(properties)
+                .setDeserializer(KafkaRecordDeserializationSchema.of(kafkaDeserializer));
+
+        return kafkaSourceBuilder.build();
+    }
+
+    private OffsetResetStrategy getResetStrategy(String offsetResetConfig) {
+        return Arrays.stream(OffsetResetStrategy.values())
+                .filter(ors -> ors.name().equals(offsetResetConfig.toUpperCase(Locale.ROOT)))
+                .findAny()
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "%s can not be set to %s. Valid values: [%s]",
+                                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                                offsetResetConfig,
+                                                Arrays.stream(OffsetResetStrategy.values())
+                                                        .map(Enum::name)
+                                                        .map(String::toLowerCase)
+                                                        .collect(Collectors.joining(",")))));
+    }
+
+    private KafkaDeserializationSchema<RowData> createKafkaDeserializationSchema(
+            DeserializationSchema<RowData> keyDeserialization,
+            DeserializationSchema<RowData> valueDeserialization,
+            TypeInformation<RowData> producedTypeInfo) {
+        final MetadataConverter[] metadataConverters =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .map(m -> m.converter)
+                        .toArray(MetadataConverter[]::new);
+
+        // check if connector metadata is used at all
+        final boolean hasMetadata = metadataKeys.size() > 0;
+
+        // adjust physical arity with value format's metadata
+        final int adjustedPhysicalArity =
+                DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
+
+        // adjust value format projection to include value format's metadata columns at the end
+        final int[] adjustedValueProjection =
+                IntStream.concat(
+                                IntStream.of(valueProjection),
+                                IntStream.range(
+                                        keyProjection.length + valueProjection.length,
+                                        adjustedPhysicalArity))
+                        .toArray();
+
+        return new SafeDynamicKafkaDeserializationSchema(
+                adjustedPhysicalArity,
+                keyDeserialization,
+                keyProjection,
+                valueDeserialization,
+                adjustedValueProjection,
+                hasMetadata,
+                metadataConverters,
+                producedTypeInfo,
+                upsertMode,
+                deserFailureHandler);
+    }
+
+    private @Nullable DeserializationSchema<RowData> createDeserialization(
+            DynamicTableSource.Context context,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+            int[] projection,
+            @Nullable String prefix) {
+        if (format == null) {
+            return null;
+        }
+        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
+        if (prefix != null) {
+            physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+        }
+        return format.createRuntimeDecoder(context, physicalFormatDataType);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    enum ReadableMetadata {
+        TOPIC(
+                "topic",
+                DataTypes.STRING().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return StringData.fromString(record.topic());
+                    }
+                }),
+
+        PARTITION(
+                "partition",
+                DataTypes.INT().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.partition();
+                    }
+                }),
+
+        HEADERS(
+                "headers",
+                // key and value of the map are nullable to make handling easier in queries
+                DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable())
+                        .notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        final Map<StringData, byte[]> map = new HashMap<>();
+                        for (Header header : record.headers()) {
+                            map.put(StringData.fromString(header.key()), header.value());
+                        }
+                        return new GenericMapData(map);
+                    }
+                }),
+
+        LEADER_EPOCH(
+                "leader-epoch",
+                DataTypes.INT().nullable(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.leaderEpoch().orElse(null);
+                    }
+                }),
+
+        OFFSET(
+                "offset",
+                DataTypes.BIGINT().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.offset();
+                    }
+                }),
+
+        TIMESTAMP(
+                "timestamp",
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return TimestampData.fromEpochMillis(record.timestamp());
+                    }
+                }),
+
+        TIMESTAMP_TYPE(
+                "timestamp-type",
+                DataTypes.STRING().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return StringData.fromString(record.timestampType().toString());
+                    }
+                });
+
+        final String key;
+
+        final DataType dataType;
+
+        final MetadataConverter converter;
+
+        ReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.converter = converter;
+        }
+    }
 }

--- a/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeKafkaDynamicTableFactory.java
+++ b/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeKafkaDynamicTableFactory.java
@@ -15,6 +15,55 @@
  */
 package org.apache.flink.streaming.connectors.kafka.table;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.streaming.connectors.kafka.config.BoundedMode;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.BoundedOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
+import com.google.auto.service.AutoService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.SCAN_DESER_FAILURE_HANDLER;
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.SCAN_DESER_FAILURE_TOPIC;
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.validateDeserFailureHandlerOptions;
@@ -52,395 +101,361 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.validateTableSinkOptions;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.validateTableSourceOptions;
 
-import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
-import com.google.auto.service.AutoService;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.connector.base.DeliveryGuarantee;
-import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
-import org.apache.flink.streaming.connectors.kafka.config.BoundedMode;
-import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
-import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
-import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.BoundedOptions;
-import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.ObjectIdentifier;
-import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.format.EncodingFormat;
-import org.apache.flink.table.connector.format.Format;
-import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.source.DynamicTableSource;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.DeserializationFormatFactory;
-import org.apache.flink.table.factories.DynamicTableSinkFactory;
-import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.factories.Factory;
-import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
-import org.apache.flink.table.factories.SerializationFormatFactory;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.types.RowKind;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Factory for creating configured instances of {@link SafeKafkaDynamicSource} and {@link
  * KafkaDynamicSink}.
  */
 @AutoService(Factory.class)
 public class SafeKafkaDynamicTableFactory
-    implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SafeKafkaDynamicTableFactory.class);
-  private static final ConfigOption<String> SINK_SEMANTIC =
-      ConfigOptions.key("sink.semantic")
-          .stringType()
-          .noDefaultValue()
-          .withDescription("Optional semantic when committing.");
+    private static final Logger LOG = LoggerFactory.getLogger(SafeKafkaDynamicTableFactory.class);
+    private static final ConfigOption<String> SINK_SEMANTIC =
+            ConfigOptions.key("sink.semantic")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional semantic when committing.");
 
-  public static final String IDENTIFIER = "kafka-safe";
+    public static final String IDENTIFIER = "kafka-safe";
 
-  @Override
-  public String factoryIdentifier() {
-    return IDENTIFIER;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> requiredOptions() {
-    final Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(PROPS_BOOTSTRAP_SERVERS);
-    return options;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> optionalOptions() {
-    final Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(FactoryUtil.FORMAT);
-    options.add(KEY_FORMAT);
-    options.add(KEY_FIELDS);
-    options.add(KEY_FIELDS_PREFIX);
-    options.add(VALUE_FORMAT);
-    options.add(VALUE_FIELDS_INCLUDE);
-    options.add(TOPIC);
-    options.add(TOPIC_PATTERN);
-    options.add(PROPS_GROUP_ID);
-    options.add(SCAN_STARTUP_MODE);
-    options.add(SCAN_STARTUP_SPECIFIC_OFFSETS);
-    options.add(SCAN_TOPIC_PARTITION_DISCOVERY);
-    options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
-    options.add(SINK_PARTITIONER);
-    options.add(SINK_PARALLELISM);
-    options.add(DELIVERY_GUARANTEE);
-    options.add(TRANSACTIONAL_ID_PREFIX);
-    options.add(SINK_SEMANTIC);
-    options.add(SCAN_BOUNDED_MODE);
-    options.add(SCAN_BOUNDED_SPECIFIC_OFFSETS);
-    options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
-    options.add(SCAN_DESER_FAILURE_HANDLER);
-    options.add(SCAN_DESER_FAILURE_TOPIC);
-    return options;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> forwardOptions() {
-    return Stream.of(
-            PROPS_BOOTSTRAP_SERVERS,
-            PROPS_GROUP_ID,
-            TOPIC,
-            TOPIC_PATTERN,
-            SCAN_STARTUP_MODE,
-            SCAN_STARTUP_SPECIFIC_OFFSETS,
-            SCAN_TOPIC_PARTITION_DISCOVERY,
-            SCAN_STARTUP_TIMESTAMP_MILLIS,
-            SINK_PARTITIONER,
-            SINK_PARALLELISM,
-            TRANSACTIONAL_ID_PREFIX)
-        .collect(Collectors.toSet());
-  }
-
-  @Override
-  public DynamicTableSource createDynamicTableSource(Context context) {
-    final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-
-    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
-        getKeyDecodingFormat(helper);
-
-    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
-        getValueDecodingFormat(helper);
-
-    helper.validateExcept(PROPERTIES_PREFIX);
-
-    final ReadableConfig tableOptions = helper.getOptions();
-
-    validateTableSourceOptions(tableOptions);
-
-    validatePKConstraints(
-        context.getObjectIdentifier(),
-        context.getPrimaryKeyIndexes(),
-        context.getCatalogTable().getOptions(),
-        valueDecodingFormat);
-
-    validateDeserFailureHandlerOptions(tableOptions);
-
-    final StartupOptions startupOptions = getStartupOptions(tableOptions);
-
-    final BoundedOptions boundedOptions = getBoundedOptions(tableOptions);
-
-    final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
-
-    // add topic-partition discovery
-    final Duration partitionDiscoveryInterval = tableOptions.get(SCAN_TOPIC_PARTITION_DISCOVERY);
-    properties.setProperty(
-        KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
-        Long.toString(partitionDiscoveryInterval.toMillis()));
-
-    final DataType physicalDataType = context.getPhysicalRowDataType();
-
-    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
-
-    final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
-
-    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
-
-    final DeserFailureHandler deserFailureHandler =
-        DeserFailureHandler.of(tableOptions, properties);
-
-    return createKafkaTableSource(
-        physicalDataType,
-        keyDecodingFormat.orElse(null),
-        valueDecodingFormat,
-        keyProjection,
-        valueProjection,
-        keyPrefix,
-        getSourceTopics(tableOptions),
-        getSourceTopicPattern(tableOptions),
-        properties,
-        startupOptions.startupMode,
-        startupOptions.specificOffsets,
-        startupOptions.startupTimestampMillis,
-        boundedOptions.boundedMode,
-        boundedOptions.specificOffsets,
-        boundedOptions.boundedTimestampMillis,
-        context.getObjectIdentifier().asSummaryString(),
-        deserFailureHandler);
-  }
-
-  @Override
-  public DynamicTableSink createDynamicTableSink(Context context) {
-    final TableFactoryHelper helper =
-        FactoryUtil.createTableFactoryHelper(this, autoCompleteSchemaRegistrySubject(context));
-
-    final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
-        getKeyEncodingFormat(helper);
-
-    final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
-        getValueEncodingFormat(helper);
-
-    helper.validateExcept(PROPERTIES_PREFIX);
-
-    final ReadableConfig tableOptions = helper.getOptions();
-
-    final DeliveryGuarantee deliveryGuarantee = validateDeprecatedSemantic(tableOptions);
-    validateTableSinkOptions(tableOptions);
-
-    KafkaConnectorOptionsUtil.validateDeliveryGuarantee(tableOptions);
-
-    validatePKConstraints(
-        context.getObjectIdentifier(),
-        context.getPrimaryKeyIndexes(),
-        context.getCatalogTable().getOptions(),
-        valueEncodingFormat);
-
-    final DataType physicalDataType = context.getPhysicalRowDataType();
-
-    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
-
-    final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
-
-    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
-
-    final Integer parallelism = tableOptions.getOptional(SINK_PARALLELISM).orElse(null);
-
-    return createKafkaTableSink(
-        physicalDataType,
-        keyEncodingFormat.orElse(null),
-        valueEncodingFormat,
-        keyProjection,
-        valueProjection,
-        keyPrefix,
-        tableOptions.get(TOPIC).get(0),
-        getKafkaProperties(context.getCatalogTable().getOptions()),
-        getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
-        deliveryGuarantee,
-        parallelism,
-        tableOptions.get(TRANSACTIONAL_ID_PREFIX));
-  }
-
-  // --------------------------------------------------------------------------------------------
-
-  private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
-      TableFactoryHelper helper) {
-    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
-        helper.discoverOptionalDecodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
-    keyDecodingFormat.ifPresent(
-        format -> {
-          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
-            throw new ValidationException(
-                String.format(
-                    "A key format should only deal with INSERT-only records. "
-                        + "But %s has a changelog mode of %s.",
-                    helper.getOptions().get(KEY_FORMAT), format.getChangelogMode()));
-          }
-        });
-    return keyDecodingFormat;
-  }
-
-  private static Optional<EncodingFormat<SerializationSchema<RowData>>> getKeyEncodingFormat(
-      TableFactoryHelper helper) {
-    final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
-        helper.discoverOptionalEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
-    keyEncodingFormat.ifPresent(
-        format -> {
-          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
-            throw new ValidationException(
-                String.format(
-                    "A key format should only deal with INSERT-only records. "
-                        + "But %s has a changelog mode of %s.",
-                    helper.getOptions().get(KEY_FORMAT), format.getChangelogMode()));
-          }
-        });
-    return keyEncodingFormat;
-  }
-
-  private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
-      TableFactoryHelper helper) {
-    return helper
-        .discoverOptionalDecodingFormat(DeserializationFormatFactory.class, FactoryUtil.FORMAT)
-        .orElseGet(
-            () -> helper.discoverDecodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT));
-  }
-
-  private static EncodingFormat<SerializationSchema<RowData>> getValueEncodingFormat(
-      TableFactoryHelper helper) {
-    return helper
-        .discoverOptionalEncodingFormat(SerializationFormatFactory.class, FactoryUtil.FORMAT)
-        .orElseGet(
-            () -> helper.discoverEncodingFormat(SerializationFormatFactory.class, VALUE_FORMAT));
-  }
-
-  private static void validatePKConstraints(
-      ObjectIdentifier tableName,
-      int[] primaryKeyIndexes,
-      Map<String, String> options,
-      Format format) {
-    if (primaryKeyIndexes.length > 0 && format.getChangelogMode().containsOnly(RowKind.INSERT)) {
-      Configuration configuration = Configuration.fromMap(options);
-      String formatName =
-          configuration.getOptional(FactoryUtil.FORMAT).orElse(configuration.get(VALUE_FORMAT));
-      throw new ValidationException(
-          String.format(
-              "The Kafka table '%s' with '%s' format doesn't support defining PRIMARY KEY constraint"
-                  + " on the table, because it can't guarantee the semantic of primary key.",
-              tableName.asSummaryString(), formatName));
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
     }
-  }
 
-  private static DeliveryGuarantee validateDeprecatedSemantic(ReadableConfig tableOptions) {
-    if (tableOptions.getOptional(SINK_SEMANTIC).isPresent()) {
-      LOG.warn(
-          "{} is deprecated and will be removed. Please use {} instead.",
-          SINK_SEMANTIC.key(),
-          DELIVERY_GUARANTEE.key());
-      return DeliveryGuarantee.valueOf(
-          tableOptions.get(SINK_SEMANTIC).toUpperCase().replace("-", "_"));
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PROPS_BOOTSTRAP_SERVERS);
+        return options;
     }
-    return tableOptions.get(DELIVERY_GUARANTEE);
-  }
 
-  // --------------------------------------------------------------------------------------------
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FactoryUtil.FORMAT);
+        options.add(KEY_FORMAT);
+        options.add(KEY_FIELDS);
+        options.add(KEY_FIELDS_PREFIX);
+        options.add(VALUE_FORMAT);
+        options.add(VALUE_FIELDS_INCLUDE);
+        options.add(TOPIC);
+        options.add(TOPIC_PATTERN);
+        options.add(PROPS_GROUP_ID);
+        options.add(SCAN_STARTUP_MODE);
+        options.add(SCAN_STARTUP_SPECIFIC_OFFSETS);
+        options.add(SCAN_TOPIC_PARTITION_DISCOVERY);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
+        options.add(SINK_PARTITIONER);
+        options.add(SINK_PARALLELISM);
+        options.add(DELIVERY_GUARANTEE);
+        options.add(TRANSACTIONAL_ID_PREFIX);
+        options.add(SINK_SEMANTIC);
+        options.add(SCAN_BOUNDED_MODE);
+        options.add(SCAN_BOUNDED_SPECIFIC_OFFSETS);
+        options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
+        options.add(SCAN_DESER_FAILURE_HANDLER);
+        options.add(SCAN_DESER_FAILURE_TOPIC);
+        return options;
+    }
 
-  protected SafeKafkaDynamicSource createKafkaTableSource(
-      DataType physicalDataType,
-      @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
-      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
-      int[] keyProjection,
-      int[] valueProjection,
-      @Nullable String keyPrefix,
-      @Nullable List<String> topics,
-      @Nullable Pattern topicPattern,
-      Properties properties,
-      StartupMode startupMode,
-      Map<KafkaTopicPartition, Long> specificStartupOffsets,
-      long startupTimestampMillis,
-      BoundedMode boundedMode,
-      Map<KafkaTopicPartition, Long> specificEndOffsets,
-      long endTimestampMillis,
-      String tableIdentifier,
-      DeserFailureHandler deserFailureHandler) {
-    return new SafeKafkaDynamicSource(
-        physicalDataType,
-        keyDecodingFormat,
-        valueDecodingFormat,
-        keyProjection,
-        valueProjection,
-        keyPrefix,
-        topics,
-        topicPattern,
-        properties,
-        startupMode,
-        specificStartupOffsets,
-        startupTimestampMillis,
-        boundedMode,
-        specificEndOffsets,
-        endTimestampMillis,
-        false,
-        tableIdentifier,
-        deserFailureHandler);
-  }
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        return Stream.of(
+                        PROPS_BOOTSTRAP_SERVERS,
+                        PROPS_GROUP_ID,
+                        TOPIC,
+                        TOPIC_PATTERN,
+                        SCAN_STARTUP_MODE,
+                        SCAN_STARTUP_SPECIFIC_OFFSETS,
+                        SCAN_TOPIC_PARTITION_DISCOVERY,
+                        SCAN_STARTUP_TIMESTAMP_MILLIS,
+                        SINK_PARTITIONER,
+                        SINK_PARALLELISM,
+                        TRANSACTIONAL_ID_PREFIX)
+                .collect(Collectors.toSet());
+    }
 
-  protected KafkaDynamicSink createKafkaTableSink(
-      DataType physicalDataType,
-      @Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
-      EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
-      int[] keyProjection,
-      int[] valueProjection,
-      @Nullable String keyPrefix,
-      String topic,
-      Properties properties,
-      FlinkKafkaPartitioner<RowData> partitioner,
-      DeliveryGuarantee deliveryGuarantee,
-      Integer parallelism,
-      @Nullable String transactionalIdPrefix) {
-    return new KafkaDynamicSink(
-        physicalDataType,
-        physicalDataType,
-        keyEncodingFormat,
-        valueEncodingFormat,
-        keyProjection,
-        valueProjection,
-        keyPrefix,
-        topic,
-        properties,
-        partitioner,
-        deliveryGuarantee,
-        false,
-        SinkBufferFlushMode.DISABLED,
-        parallelism,
-        transactionalIdPrefix);
-  }
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+
+        final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+                getKeyDecodingFormat(helper);
+
+        final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                getValueDecodingFormat(helper);
+
+        helper.validateExcept(PROPERTIES_PREFIX);
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        validateTableSourceOptions(tableOptions);
+
+        validatePKConstraints(
+                context.getObjectIdentifier(),
+                context.getPrimaryKeyIndexes(),
+                context.getCatalogTable().getOptions(),
+                valueDecodingFormat);
+
+        validateDeserFailureHandlerOptions(tableOptions);
+
+        final StartupOptions startupOptions = getStartupOptions(tableOptions);
+
+        final BoundedOptions boundedOptions = getBoundedOptions(tableOptions);
+
+        final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+
+        // add topic-partition discovery
+        final Duration partitionDiscoveryInterval =
+                tableOptions.get(SCAN_TOPIC_PARTITION_DISCOVERY);
+        properties.setProperty(
+                KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
+                Long.toString(partitionDiscoveryInterval.toMillis()));
+
+        final DataType physicalDataType = context.getPhysicalRowDataType();
+
+        final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+
+        final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+
+        final DeserFailureHandler deserFailureHandler =
+                DeserFailureHandler.of(tableOptions, properties);
+
+        return createKafkaTableSource(
+                physicalDataType,
+                keyDecodingFormat.orElse(null),
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                getSourceTopics(tableOptions),
+                getSourceTopicPattern(tableOptions),
+                properties,
+                startupOptions.startupMode,
+                startupOptions.specificOffsets,
+                startupOptions.startupTimestampMillis,
+                boundedOptions.boundedMode,
+                boundedOptions.specificOffsets,
+                boundedOptions.boundedTimestampMillis,
+                context.getObjectIdentifier().asSummaryString(),
+                deserFailureHandler);
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        final TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
+
+        final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+                getKeyEncodingFormat(helper);
+
+        final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+                getValueEncodingFormat(helper);
+
+        helper.validateExcept(PROPERTIES_PREFIX);
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        final DeliveryGuarantee deliveryGuarantee = validateDeprecatedSemantic(tableOptions);
+        validateTableSinkOptions(tableOptions);
+
+        KafkaConnectorOptionsUtil.validateDeliveryGuarantee(tableOptions);
+
+        validatePKConstraints(
+                context.getObjectIdentifier(),
+                context.getPrimaryKeyIndexes(),
+                context.getCatalogTable().getOptions(),
+                valueEncodingFormat);
+
+        final DataType physicalDataType = context.getPhysicalRowDataType();
+
+        final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+
+        final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+
+        final Integer parallelism = tableOptions.getOptional(SINK_PARALLELISM).orElse(null);
+
+        return createKafkaTableSink(
+                physicalDataType,
+                keyEncodingFormat.orElse(null),
+                valueEncodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                tableOptions.get(TOPIC).get(0),
+                getKafkaProperties(context.getCatalogTable().getOptions()),
+                getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
+                deliveryGuarantee,
+                parallelism,
+                tableOptions.get(TRANSACTIONAL_ID_PREFIX));
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+            TableFactoryHelper helper) {
+        final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+                helper.discoverOptionalDecodingFormat(
+                        DeserializationFormatFactory.class, KEY_FORMAT);
+        keyDecodingFormat.ifPresent(
+                format -> {
+                    if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "A key format should only deal with INSERT-only records. "
+                                                + "But %s has a changelog mode of %s.",
+                                        helper.getOptions().get(KEY_FORMAT),
+                                        format.getChangelogMode()));
+                    }
+                });
+        return keyDecodingFormat;
+    }
+
+    private static Optional<EncodingFormat<SerializationSchema<RowData>>> getKeyEncodingFormat(
+            TableFactoryHelper helper) {
+        final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+                helper.discoverOptionalEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
+        keyEncodingFormat.ifPresent(
+                format -> {
+                    if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "A key format should only deal with INSERT-only records. "
+                                                + "But %s has a changelog mode of %s.",
+                                        helper.getOptions().get(KEY_FORMAT),
+                                        format.getChangelogMode()));
+                    }
+                });
+        return keyEncodingFormat;
+    }
+
+    private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+            TableFactoryHelper helper) {
+        return helper.discoverOptionalDecodingFormat(
+                        DeserializationFormatFactory.class, FactoryUtil.FORMAT)
+                .orElseGet(
+                        () ->
+                                helper.discoverDecodingFormat(
+                                        DeserializationFormatFactory.class, VALUE_FORMAT));
+    }
+
+    private static EncodingFormat<SerializationSchema<RowData>> getValueEncodingFormat(
+            TableFactoryHelper helper) {
+        return helper.discoverOptionalEncodingFormat(
+                        SerializationFormatFactory.class, FactoryUtil.FORMAT)
+                .orElseGet(
+                        () ->
+                                helper.discoverEncodingFormat(
+                                        SerializationFormatFactory.class, VALUE_FORMAT));
+    }
+
+    private static void validatePKConstraints(
+            ObjectIdentifier tableName,
+            int[] primaryKeyIndexes,
+            Map<String, String> options,
+            Format format) {
+        if (primaryKeyIndexes.length > 0
+                && format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            Configuration configuration = Configuration.fromMap(options);
+            String formatName =
+                    configuration
+                            .getOptional(FactoryUtil.FORMAT)
+                            .orElse(configuration.get(VALUE_FORMAT));
+            throw new ValidationException(
+                    String.format(
+                            "The Kafka table '%s' with '%s' format doesn't support defining PRIMARY KEY constraint"
+                                    + " on the table, because it can't guarantee the semantic of primary key.",
+                            tableName.asSummaryString(), formatName));
+        }
+    }
+
+    private static DeliveryGuarantee validateDeprecatedSemantic(ReadableConfig tableOptions) {
+        if (tableOptions.getOptional(SINK_SEMANTIC).isPresent()) {
+            LOG.warn(
+                    "{} is deprecated and will be removed. Please use {} instead.",
+                    SINK_SEMANTIC.key(),
+                    DELIVERY_GUARANTEE.key());
+            return DeliveryGuarantee.valueOf(
+                    tableOptions.get(SINK_SEMANTIC).toUpperCase().replace("-", "_"));
+        }
+        return tableOptions.get(DELIVERY_GUARANTEE);
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    protected SafeKafkaDynamicSource createKafkaTableSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<KafkaTopicPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis,
+            BoundedMode boundedMode,
+            Map<KafkaTopicPartition, Long> specificEndOffsets,
+            long endTimestampMillis,
+            String tableIdentifier,
+            DeserFailureHandler deserFailureHandler) {
+        return new SafeKafkaDynamicSource(
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                boundedMode,
+                specificEndOffsets,
+                endTimestampMillis,
+                false,
+                tableIdentifier,
+                deserFailureHandler);
+    }
+
+    protected KafkaDynamicSink createKafkaTableSink(
+            DataType physicalDataType,
+            @Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
+            EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            String topic,
+            Properties properties,
+            FlinkKafkaPartitioner<RowData> partitioner,
+            DeliveryGuarantee deliveryGuarantee,
+            Integer parallelism,
+            @Nullable String transactionalIdPrefix) {
+        return new KafkaDynamicSink(
+                physicalDataType,
+                physicalDataType,
+                keyEncodingFormat,
+                valueEncodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topic,
+                properties,
+                partitioner,
+                deliveryGuarantee,
+                false,
+                SinkBufferFlushMode.DISABLED,
+                parallelism,
+                transactionalIdPrefix);
+    }
 }

--- a/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeUpsertKafkaDynamicTableFactory.java
+++ b/connectors/kafka-safe-connector/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SafeUpsertKafkaDynamicTableFactory.java
@@ -15,6 +15,46 @@
  */
 package org.apache.flink.streaming.connectors.kafka.table;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.BoundedOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
+import com.google.auto.service.AutoService;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.SCAN_DESER_FAILURE_HANDLER;
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.SCAN_DESER_FAILURE_TOPIC;
 import static com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandlerOptions.validateDeserFailureHandlerOptions;
@@ -43,378 +83,357 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.getSourceTopics;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.validateScanBoundedMode;
 
-import com.datasqrl.flinkrunner.connector.kafka.DeserFailureHandler;
-import com.google.auto.service.AutoService;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.BoundedOptions;
-import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
-import org.apache.flink.table.catalog.ResolvedSchema;
-import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.format.EncodingFormat;
-import org.apache.flink.table.connector.format.Format;
-import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.source.DynamicTableSource;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.DeserializationFormatFactory;
-import org.apache.flink.table.factories.DynamicTableSinkFactory;
-import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.factories.Factory;
-import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.table.factories.SerializationFormatFactory;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.types.RowKind;
-
 /** Upsert-Kafka factory. */
 @AutoService(Factory.class)
 public class SafeUpsertKafkaDynamicTableFactory
-    implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
-  public static final String IDENTIFIER = "upsert-kafka-safe";
+    public static final String IDENTIFIER = "upsert-kafka-safe";
 
-  @Override
-  public String factoryIdentifier() {
-    return IDENTIFIER;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> requiredOptions() {
-    final Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(PROPS_BOOTSTRAP_SERVERS);
-    options.add(TOPIC);
-    options.add(KEY_FORMAT);
-    options.add(VALUE_FORMAT);
-    return options;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> optionalOptions() {
-    final Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(KEY_FIELDS_PREFIX);
-    options.add(VALUE_FIELDS_INCLUDE);
-    options.add(SINK_PARALLELISM);
-    options.add(SINK_BUFFER_FLUSH_INTERVAL);
-    options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
-    options.add(SCAN_BOUNDED_MODE);
-    options.add(SCAN_BOUNDED_SPECIFIC_OFFSETS);
-    options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
-    options.add(SCAN_DESER_FAILURE_HANDLER);
-    options.add(SCAN_DESER_FAILURE_TOPIC);
-    options.add(DELIVERY_GUARANTEE);
-    options.add(TRANSACTIONAL_ID_PREFIX);
-    return options;
-  }
-
-  @Override
-  public Set<ConfigOption<?>> forwardOptions() {
-    return Stream.of(DELIVERY_GUARANTEE, TRANSACTIONAL_ID_PREFIX).collect(Collectors.toSet());
-  }
-
-  @Override
-  public DynamicTableSource createDynamicTableSource(Context context) {
-    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-
-    ReadableConfig tableOptions = helper.getOptions();
-    DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat =
-        helper.discoverDecodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
-    DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
-        helper.discoverDecodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
-
-    // Validate the option data type.
-    helper.validateExcept(PROPERTIES_PREFIX);
-    validateSource(
-        tableOptions, keyDecodingFormat, valueDecodingFormat, context.getPrimaryKeyIndexes());
-
-    Tuple2<int[], int[]> keyValueProjections = createKeyValueProjections(context.getCatalogTable());
-    String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
-    Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
-    // always use earliest to keep data integrity
-    StartupMode earliest = StartupMode.EARLIEST;
-
-    final BoundedOptions boundedOptions = getBoundedOptions(tableOptions);
-
-    final DeserFailureHandler deserFailureHandler =
-        DeserFailureHandler.of(tableOptions, properties);
-
-    return new SafeKafkaDynamicSource(
-        context.getPhysicalRowDataType(),
-        keyDecodingFormat,
-        new DecodingFormatWrapper(valueDecodingFormat),
-        keyValueProjections.f0,
-        keyValueProjections.f1,
-        keyPrefix,
-        getSourceTopics(tableOptions),
-        getSourceTopicPattern(tableOptions),
-        properties,
-        earliest,
-        Collections.emptyMap(),
-        0,
-        boundedOptions.boundedMode,
-        boundedOptions.specificOffsets,
-        boundedOptions.boundedTimestampMillis,
-        true,
-        context.getObjectIdentifier().asSummaryString(),
-        deserFailureHandler);
-  }
-
-  @Override
-  public DynamicTableSink createDynamicTableSink(Context context) {
-    FactoryUtil.TableFactoryHelper helper =
-        FactoryUtil.createTableFactoryHelper(this, autoCompleteSchemaRegistrySubject(context));
-
-    final ReadableConfig tableOptions = helper.getOptions();
-
-    EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat =
-        helper.discoverEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
-    EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
-        helper.discoverEncodingFormat(SerializationFormatFactory.class, VALUE_FORMAT);
-
-    // Validate the option data type.
-    helper.validateExcept(PROPERTIES_PREFIX);
-    validateSink(
-        tableOptions, keyEncodingFormat, valueEncodingFormat, context.getPrimaryKeyIndexes());
-    KafkaConnectorOptionsUtil.validateDeliveryGuarantee(tableOptions);
-
-    Tuple2<int[], int[]> keyValueProjections = createKeyValueProjections(context.getCatalogTable());
-    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
-    final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
-
-    Integer parallelism = tableOptions.get(SINK_PARALLELISM);
-
-    int batchSize = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
-    Duration batchInterval = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL);
-    SinkBufferFlushMode flushMode = new SinkBufferFlushMode(batchSize, batchInterval.toMillis());
-
-    // use {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner}.
-    // it will use hash partition if key is set else in round-robin behaviour.
-    return new KafkaDynamicSink(
-        context.getPhysicalRowDataType(),
-        context.getPhysicalRowDataType(),
-        keyEncodingFormat,
-        new EncodingFormatWrapper(valueEncodingFormat),
-        keyValueProjections.f0,
-        keyValueProjections.f1,
-        keyPrefix,
-        tableOptions.get(TOPIC).get(0),
-        properties,
-        null,
-        tableOptions.get(DELIVERY_GUARANTEE),
-        true,
-        flushMode,
-        parallelism,
-        tableOptions.get(TRANSACTIONAL_ID_PREFIX));
-  }
-
-  private Tuple2<int[], int[]> createKeyValueProjections(ResolvedCatalogTable catalogTable) {
-    ResolvedSchema schema = catalogTable.getResolvedSchema();
-    // primary key should validated earlier
-    List<String> keyFields = schema.getPrimaryKey().get().getColumns();
-    DataType physicalDataType = schema.toPhysicalRowDataType();
-
-    Configuration tableOptions = Configuration.fromMap(catalogTable.getOptions());
-    // upsert-kafka will set key.fields to primary key fields by default
-    tableOptions.set(KEY_FIELDS, keyFields);
-
-    int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
-    int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
-
-    return Tuple2.of(keyProjection, valueProjection);
-  }
-
-  // --------------------------------------------------------------------------------------------
-  // Validation
-  // --------------------------------------------------------------------------------------------
-
-  private static void validateSource(
-      ReadableConfig tableOptions, Format keyFormat, Format valueFormat, int[] primaryKeyIndexes) {
-    validateTopic(tableOptions);
-    validateScanBoundedMode(tableOptions);
-    validateFormat(keyFormat, valueFormat, tableOptions);
-    validatePKConstraints(primaryKeyIndexes);
-    validateDeserFailureHandlerOptions(tableOptions);
-  }
-
-  private static void validateSink(
-      ReadableConfig tableOptions, Format keyFormat, Format valueFormat, int[] primaryKeyIndexes) {
-    validateTopic(tableOptions);
-    validateFormat(keyFormat, valueFormat, tableOptions);
-    validatePKConstraints(primaryKeyIndexes);
-    validateSinkBufferFlush(tableOptions);
-  }
-
-  private static void validateTopic(ReadableConfig tableOptions) {
-    List<String> topic = tableOptions.get(TOPIC);
-    if (topic.size() > 1) {
-      throw new ValidationException(
-          "The 'upsert-kafka' connector doesn't support topic list now. "
-              + "Please use single topic as the value of the parameter 'topic'.");
-    }
-  }
-
-  private static void validateFormat(
-      Format keyFormat, Format valueFormat, ReadableConfig tableOptions) {
-    if (!keyFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
-      String identifier = tableOptions.get(KEY_FORMAT);
-      throw new ValidationException(
-          String.format(
-              "'upsert-kafka' connector doesn't support '%s' as key format, "
-                  + "because '%s' is not in insert-only mode.",
-              identifier, identifier));
-    }
-    if (!valueFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
-      String identifier = tableOptions.get(VALUE_FORMAT);
-      throw new ValidationException(
-          String.format(
-              "'upsert-kafka' connector doesn't support '%s' as value format, "
-                  + "because '%s' is not in insert-only mode.",
-              identifier, identifier));
-    }
-  }
-
-  private static void validatePKConstraints(int[] schema) {
-    if (schema.length == 0) {
-      throw new ValidationException(
-          "'upsert-kafka' tables require to define a PRIMARY KEY constraint. "
-              + "The PRIMARY KEY specifies which columns should be read from or write to the Kafka message key. "
-              + "The PRIMARY KEY also defines records in the 'upsert-kafka' table should update or delete on which keys.");
-    }
-  }
-
-  private static void validateSinkBufferFlush(ReadableConfig tableOptions) {
-    int flushMaxRows = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
-    long flushIntervalMs = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis();
-    if (flushMaxRows > 0 && flushIntervalMs > 0) {
-      // flush is enabled
-      return;
-    }
-    if (flushMaxRows <= 0 && flushIntervalMs <= 0) {
-      // flush is disabled
-      return;
-    }
-    // one of them is set which is not allowed
-    throw new ValidationException(
-        String.format(
-            "'%s' and '%s' must be set to be greater than zero together to enable sink buffer flushing.",
-            SINK_BUFFER_FLUSH_MAX_ROWS.key(), SINK_BUFFER_FLUSH_INTERVAL.key()));
-  }
-
-  // --------------------------------------------------------------------------------------------
-  // Format wrapper
-  // --------------------------------------------------------------------------------------------
-
-  /**
-   * It is used to wrap the decoding format and expose the desired changelog mode. It's only works
-   * for insert-only format.
-   */
-  protected static class DecodingFormatWrapper
-      implements DecodingFormat<DeserializationSchema<RowData>> {
-    private final DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat;
-
-    private static final ChangelogMode SOURCE_CHANGELOG_MODE =
-        ChangelogMode.newBuilder()
-            .addContainedKind(RowKind.UPDATE_AFTER)
-            .addContainedKind(RowKind.DELETE)
-            .build();
-
-    public DecodingFormatWrapper(
-        DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat) {
-      this.innerDecodingFormat = innerDecodingFormat;
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
     }
 
     @Override
-    public DeserializationSchema<RowData> createRuntimeDecoder(
-        DynamicTableSource.Context context, DataType producedDataType) {
-      return innerDecodingFormat.createRuntimeDecoder(context, producedDataType);
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PROPS_BOOTSTRAP_SERVERS);
+        options.add(TOPIC);
+        options.add(KEY_FORMAT);
+        options.add(VALUE_FORMAT);
+        return options;
     }
 
     @Override
-    public ChangelogMode getChangelogMode() {
-      return SOURCE_CHANGELOG_MODE;
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(KEY_FIELDS_PREFIX);
+        options.add(VALUE_FIELDS_INCLUDE);
+        options.add(SINK_PARALLELISM);
+        options.add(SINK_BUFFER_FLUSH_INTERVAL);
+        options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
+        options.add(SCAN_BOUNDED_MODE);
+        options.add(SCAN_BOUNDED_SPECIFIC_OFFSETS);
+        options.add(SCAN_BOUNDED_TIMESTAMP_MILLIS);
+        options.add(SCAN_DESER_FAILURE_HANDLER);
+        options.add(SCAN_DESER_FAILURE_TOPIC);
+        options.add(DELIVERY_GUARANTEE);
+        options.add(TRANSACTIONAL_ID_PREFIX);
+        return options;
     }
 
     @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
-
-      if (obj == null || getClass() != obj.getClass()) {
-        return false;
-      }
-
-      DecodingFormatWrapper that = (DecodingFormatWrapper) obj;
-      return Objects.equals(innerDecodingFormat, that.innerDecodingFormat);
+    public Set<ConfigOption<?>> forwardOptions() {
+        return Stream.of(DELIVERY_GUARANTEE, TRANSACTIONAL_ID_PREFIX).collect(Collectors.toSet());
     }
 
     @Override
-    public int hashCode() {
-      return Objects.hash(innerDecodingFormat);
-    }
-  }
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-  /**
-   * It is used to wrap the encoding format and expose the desired changelog mode. It's only works
-   * for insert-only format.
-   */
-  protected static class EncodingFormatWrapper
-      implements EncodingFormat<SerializationSchema<RowData>> {
-    private final EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat;
+        ReadableConfig tableOptions = helper.getOptions();
+        DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat =
+                helper.discoverDecodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
+        DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                helper.discoverDecodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
 
-    public static final ChangelogMode SINK_CHANGELOG_MODE =
-        ChangelogMode.newBuilder()
-            .addContainedKind(RowKind.INSERT)
-            .addContainedKind(RowKind.UPDATE_AFTER)
-            .addContainedKind(RowKind.DELETE)
-            .build();
+        // Validate the option data type.
+        helper.validateExcept(PROPERTIES_PREFIX);
+        validateSource(
+                tableOptions,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                context.getPrimaryKeyIndexes());
 
-    public EncodingFormatWrapper(EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat) {
-      this.innerEncodingFormat = innerEncodingFormat;
+        Tuple2<int[], int[]> keyValueProjections =
+                createKeyValueProjections(context.getCatalogTable());
+        String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+        Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+        // always use earliest to keep data integrity
+        StartupMode earliest = StartupMode.EARLIEST;
+
+        final BoundedOptions boundedOptions = getBoundedOptions(tableOptions);
+
+        final DeserFailureHandler deserFailureHandler =
+                DeserFailureHandler.of(tableOptions, properties);
+
+        return new SafeKafkaDynamicSource(
+                context.getPhysicalRowDataType(),
+                keyDecodingFormat,
+                new DecodingFormatWrapper(valueDecodingFormat),
+                keyValueProjections.f0,
+                keyValueProjections.f1,
+                keyPrefix,
+                getSourceTopics(tableOptions),
+                getSourceTopicPattern(tableOptions),
+                properties,
+                earliest,
+                Collections.emptyMap(),
+                0,
+                boundedOptions.boundedMode,
+                boundedOptions.specificOffsets,
+                boundedOptions.boundedTimestampMillis,
+                true,
+                context.getObjectIdentifier().asSummaryString(),
+                deserFailureHandler);
     }
 
     @Override
-    public SerializationSchema<RowData> createRuntimeEncoder(
-        DynamicTableSink.Context context, DataType consumedDataType) {
-      return innerEncodingFormat.createRuntimeEncoder(context, consumedDataType);
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat =
+                helper.discoverEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
+        EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+                helper.discoverEncodingFormat(SerializationFormatFactory.class, VALUE_FORMAT);
+
+        // Validate the option data type.
+        helper.validateExcept(PROPERTIES_PREFIX);
+        validateSink(
+                tableOptions,
+                keyEncodingFormat,
+                valueEncodingFormat,
+                context.getPrimaryKeyIndexes());
+        KafkaConnectorOptionsUtil.validateDeliveryGuarantee(tableOptions);
+
+        Tuple2<int[], int[]> keyValueProjections =
+                createKeyValueProjections(context.getCatalogTable());
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+        final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+
+        Integer parallelism = tableOptions.get(SINK_PARALLELISM);
+
+        int batchSize = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        Duration batchInterval = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL);
+        SinkBufferFlushMode flushMode =
+                new SinkBufferFlushMode(batchSize, batchInterval.toMillis());
+
+        // use {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner}.
+        // it will use hash partition if key is set else in round-robin behaviour.
+        return new KafkaDynamicSink(
+                context.getPhysicalRowDataType(),
+                context.getPhysicalRowDataType(),
+                keyEncodingFormat,
+                new EncodingFormatWrapper(valueEncodingFormat),
+                keyValueProjections.f0,
+                keyValueProjections.f1,
+                keyPrefix,
+                tableOptions.get(TOPIC).get(0),
+                properties,
+                null,
+                tableOptions.get(DELIVERY_GUARANTEE),
+                true,
+                flushMode,
+                parallelism,
+                tableOptions.get(TRANSACTIONAL_ID_PREFIX));
     }
 
-    @Override
-    public ChangelogMode getChangelogMode() {
-      return SINK_CHANGELOG_MODE;
+    private Tuple2<int[], int[]> createKeyValueProjections(ResolvedCatalogTable catalogTable) {
+        ResolvedSchema schema = catalogTable.getResolvedSchema();
+        // primary key should validated earlier
+        List<String> keyFields = schema.getPrimaryKey().get().getColumns();
+        DataType physicalDataType = schema.toPhysicalRowDataType();
+
+        Configuration tableOptions = Configuration.fromMap(catalogTable.getOptions());
+        // upsert-kafka will set key.fields to primary key fields by default
+        tableOptions.set(KEY_FIELDS, keyFields);
+
+        int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+        int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        return Tuple2.of(keyProjection, valueProjection);
     }
 
-    @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
+    // --------------------------------------------------------------------------------------------
+    // Validation
+    // --------------------------------------------------------------------------------------------
 
-      if (obj == null || getClass() != obj.getClass()) {
-        return false;
-      }
-
-      EncodingFormatWrapper that = (EncodingFormatWrapper) obj;
-      return Objects.equals(innerEncodingFormat, that.innerEncodingFormat);
+    private static void validateSource(
+            ReadableConfig tableOptions,
+            Format keyFormat,
+            Format valueFormat,
+            int[] primaryKeyIndexes) {
+        validateTopic(tableOptions);
+        validateScanBoundedMode(tableOptions);
+        validateFormat(keyFormat, valueFormat, tableOptions);
+        validatePKConstraints(primaryKeyIndexes);
+        validateDeserFailureHandlerOptions(tableOptions);
     }
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(innerEncodingFormat);
+    private static void validateSink(
+            ReadableConfig tableOptions,
+            Format keyFormat,
+            Format valueFormat,
+            int[] primaryKeyIndexes) {
+        validateTopic(tableOptions);
+        validateFormat(keyFormat, valueFormat, tableOptions);
+        validatePKConstraints(primaryKeyIndexes);
+        validateSinkBufferFlush(tableOptions);
     }
-  }
+
+    private static void validateTopic(ReadableConfig tableOptions) {
+        List<String> topic = tableOptions.get(TOPIC);
+        if (topic.size() > 1) {
+            throw new ValidationException(
+                    "The 'upsert-kafka' connector doesn't support topic list now. "
+                            + "Please use single topic as the value of the parameter 'topic'.");
+        }
+    }
+
+    private static void validateFormat(
+            Format keyFormat, Format valueFormat, ReadableConfig tableOptions) {
+        if (!keyFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            String identifier = tableOptions.get(KEY_FORMAT);
+            throw new ValidationException(
+                    String.format(
+                            "'upsert-kafka' connector doesn't support '%s' as key format, "
+                                    + "because '%s' is not in insert-only mode.",
+                            identifier, identifier));
+        }
+        if (!valueFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            String identifier = tableOptions.get(VALUE_FORMAT);
+            throw new ValidationException(
+                    String.format(
+                            "'upsert-kafka' connector doesn't support '%s' as value format, "
+                                    + "because '%s' is not in insert-only mode.",
+                            identifier, identifier));
+        }
+    }
+
+    private static void validatePKConstraints(int[] schema) {
+        if (schema.length == 0) {
+            throw new ValidationException(
+                    "'upsert-kafka' tables require to define a PRIMARY KEY constraint. "
+                            + "The PRIMARY KEY specifies which columns should be read from or write to the Kafka message key. "
+                            + "The PRIMARY KEY also defines records in the 'upsert-kafka' table should update or delete on which keys.");
+        }
+    }
+
+    private static void validateSinkBufferFlush(ReadableConfig tableOptions) {
+        int flushMaxRows = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        long flushIntervalMs = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis();
+        if (flushMaxRows > 0 && flushIntervalMs > 0) {
+            // flush is enabled
+            return;
+        }
+        if (flushMaxRows <= 0 && flushIntervalMs <= 0) {
+            // flush is disabled
+            return;
+        }
+        // one of them is set which is not allowed
+        throw new ValidationException(
+                String.format(
+                        "'%s' and '%s' must be set to be greater than zero together to enable sink buffer flushing.",
+                        SINK_BUFFER_FLUSH_MAX_ROWS.key(), SINK_BUFFER_FLUSH_INTERVAL.key()));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Format wrapper
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * It is used to wrap the decoding format and expose the desired changelog mode. It's only works
+     * for insert-only format.
+     */
+    protected static class DecodingFormatWrapper
+            implements DecodingFormat<DeserializationSchema<RowData>> {
+        private final DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat;
+
+        private static final ChangelogMode SOURCE_CHANGELOG_MODE =
+                ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+
+        public DecodingFormatWrapper(
+                DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat) {
+            this.innerDecodingFormat = innerDecodingFormat;
+        }
+
+        @Override
+        public DeserializationSchema<RowData> createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType producedDataType) {
+            return innerDecodingFormat.createRuntimeDecoder(context, producedDataType);
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return SOURCE_CHANGELOG_MODE;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            DecodingFormatWrapper that = (DecodingFormatWrapper) obj;
+            return Objects.equals(innerDecodingFormat, that.innerDecodingFormat);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(innerDecodingFormat);
+        }
+    }
+
+    /**
+     * It is used to wrap the encoding format and expose the desired changelog mode. It's only works
+     * for insert-only format.
+     */
+    protected static class EncodingFormatWrapper
+            implements EncodingFormat<SerializationSchema<RowData>> {
+        private final EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat;
+
+        public static final ChangelogMode SINK_CHANGELOG_MODE =
+                ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+
+        public EncodingFormatWrapper(
+                EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat) {
+            this.innerEncodingFormat = innerEncodingFormat;
+        }
+
+        @Override
+        public SerializationSchema<RowData> createRuntimeEncoder(
+                DynamicTableSink.Context context, DataType consumedDataType) {
+            return innerEncodingFormat.createRuntimeEncoder(context, consumedDataType);
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return SINK_CHANGELOG_MODE;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            EncodingFormatWrapper that = (EncodingFormatWrapper) obj;
+            return Objects.equals(innerEncodingFormat, that.innerEncodingFormat);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(innerEncodingFormat);
+        }
+    }
 }

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -102,12 +102,6 @@
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>com.nextbreakpoint</groupId>
@@ -330,7 +324,7 @@
                 </filter>
               </filters>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>com.datasqrl.FlinkMain</mainClass>
                 </transformer>
@@ -360,7 +354,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>${exec.plugin.version}</version>
+        <version>${exec-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>build-docker-image</id>
@@ -386,7 +380,7 @@
       <plugin>
         <groupId>com.marvinformatics</groupId>
         <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>${docker-compose-plugin.version}</version>
+        <version>${docker-compose-maven-plugin.version}</version>
         <configuration>
           <skip>${skipTests}</skip>
           <composeFile>${project.basedir}/target/docker-compose.yml</composeFile>
@@ -491,7 +485,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec.plugin.version}</version>
+            <version>${exec-maven-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/flink-sql-runner/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-sql-runner/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -15,9 +15,15 @@
  */
 package org.apache.flink.formats.avro;
 
-import java.io.IOException;
-import java.util.Objects;
-import javax.annotation.Nullable;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
+import org.apache.flink.formats.avro.typeutils.AvroFactory;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
+import org.apache.flink.util.Preconditions;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
@@ -28,14 +34,11 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
-import org.apache.flink.formats.avro.typeutils.AvroFactory;
-import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
-import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
-import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
-import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Deserialization schema that deserializes from Avro binary format.
@@ -44,203 +47,206 @@ import org.apache.flink.util.Preconditions;
  */
 public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 
-  /**
-   * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided
-   * schema.
-   *
-   * @param schema schema of produced records
-   * @return deserialized record in form of {@link GenericRecord}
-   */
-  public static AvroDeserializationSchema<GenericRecord> forGeneric(Schema schema) {
-    return forGeneric(schema, AvroEncoding.BINARY);
-  }
-
-  /**
-   * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided
-   * schema.
-   *
-   * @param schema schema of produced records
-   * @param encoding Avro serialization approach to use for decoding
-   * @return deserialized record in form of {@link GenericRecord}
-   */
-  public static AvroDeserializationSchema<GenericRecord> forGeneric(
-      Schema schema, AvroEncoding encoding) {
-    return new AvroDeserializationSchema<>(GenericRecord.class, schema, encoding);
-  }
-
-  /**
-   * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
-   * schema.
-   *
-   * @param tClass class of record to be produced
-   * @return deserialized record
-   */
-  public static <T extends SpecificRecord> AvroDeserializationSchema<T> forSpecific(
-      Class<T> tClass) {
-    return forSpecific(tClass, AvroEncoding.BINARY);
-  }
-
-  /**
-   * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
-   * schema.
-   *
-   * @param tClass class of record to be produced
-   * @param encoding Avro serialization approach to use for decoding
-   * @return deserialized record
-   */
-  public static <T extends SpecificRecord> AvroDeserializationSchema<T> forSpecific(
-      Class<T> tClass, AvroEncoding encoding) {
-    return new AvroDeserializationSchema<>(tClass, null, encoding);
-  }
-
-  private static final long serialVersionUID = -6766681879020862312L;
-
-  /** Class to deserialize to. */
-  private final Class<T> recordClazz;
-
-  /** Schema in case of GenericRecord for serialization purpose. */
-  private final String schemaString;
-
-  /** Reader that deserializes byte array into a record. */
-  private transient GenericDatumReader<T> datumReader;
-
-  /** Input stream to read message from. */
-  private transient MutableByteArrayInputStream inputStream;
-
-  /** Config option for the deserialization approach to use. */
-  private final AvroEncoding encoding;
-
-  /** Avro decoder that decodes data. */
-  private transient Decoder decoder;
-
-  /** Avro schema for the reader. */
-  private transient Schema reader;
-
-  /**
-   * Creates a Avro deserialization schema.
-   *
-   * @param recordClazz class to which deserialize. Should be one of: {@link
-   *     org.apache.avro.specific.SpecificRecord}, {@link org.apache.avro.generic.GenericRecord}.
-   * @param reader reader's Avro schema. Should be provided if recordClazz is {@link GenericRecord}
-   * @param encoding encoding approach to use. Identifies the Avro decoder class to use.
-   */
-  AvroDeserializationSchema(Class<T> recordClazz, @Nullable Schema reader, AvroEncoding encoding) {
-    Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
-    this.recordClazz = recordClazz;
-    this.reader = reader;
-    if (reader != null) {
-      this.schemaString = reader.toString();
-    } else {
-      this.schemaString = null;
-    }
-    this.encoding = encoding;
-  }
-
-  GenericDatumReader<T> getDatumReader() {
-    return datumReader;
-  }
-
-  Schema getReaderSchema() {
-    return reader;
-  }
-
-  MutableByteArrayInputStream getInputStream() {
-    return inputStream;
-  }
-
-  Decoder getDecoder() {
-    return decoder;
-  }
-
-  AvroEncoding getEncoding() {
-    return encoding;
-  }
-
-  @Override
-  public T deserialize(@Nullable byte[] message) throws IOException {
-    if (message == null) {
-      return null;
-    }
-    // read record
-    checkAvroInitialized();
-    inputStream.setBuffer(message);
-    Schema readerSchema = getReaderSchema();
-    GenericDatumReader<T> datumReader = getDatumReader();
-
-    datumReader.setSchema(readerSchema);
-
-    if (encoding == AvroEncoding.JSON) {
-      ((JsonDecoder) this.decoder).configure(inputStream);
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided
+     * schema.
+     *
+     * @param schema schema of produced records
+     * @return deserialized record in form of {@link GenericRecord}
+     */
+    public static AvroDeserializationSchema<GenericRecord> forGeneric(Schema schema) {
+        return forGeneric(schema, AvroEncoding.BINARY);
     }
 
-    try {
-      return datumReader.read(null, decoder);
-    } catch (Exception e) {
-      /*
-       * If the deserialization fails, {@code datumReader} has to be reset, because {@code Decoder} will remain in an
-       * inconsistent state, which will make subsequent valid deserialization attempts to fail.
-       */
-      this.datumReader = null;
-      throw e;
-    }
-  }
-
-  void checkAvroInitialized() throws IOException {
-    if (datumReader != null) {
-      return;
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided
+     * schema.
+     *
+     * @param schema schema of produced records
+     * @param encoding Avro serialization approach to use for decoding
+     * @return deserialized record in form of {@link GenericRecord}
+     */
+    public static AvroDeserializationSchema<GenericRecord> forGeneric(
+            Schema schema, AvroEncoding encoding) {
+        return new AvroDeserializationSchema<>(GenericRecord.class, schema, encoding);
     }
 
-    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
-      @SuppressWarnings("unchecked")
-      SpecificData specificData =
-          AvroFactory.getSpecificDataForClass((Class<? extends SpecificData>) recordClazz, cl);
-      this.datumReader = new SpecificDatumReader<>(specificData);
-      this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
-    } else {
-      this.reader = new Schema.Parser().parse(schemaString);
-      GenericData genericData = new GenericData(cl);
-      this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
+     * schema.
+     *
+     * @param tClass class of record to be produced
+     * @return deserialized record
+     */
+    public static <T extends SpecificRecord> AvroDeserializationSchema<T> forSpecific(
+            Class<T> tClass) {
+        return forSpecific(tClass, AvroEncoding.BINARY);
     }
 
-    this.inputStream = new MutableByteArrayInputStream();
-
-    if (encoding == AvroEncoding.JSON) {
-      this.decoder = DecoderFactory.get().jsonDecoder(getReaderSchema(), inputStream);
-    } else {
-      this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
+     * schema.
+     *
+     * @param tClass class of record to be produced
+     * @param encoding Avro serialization approach to use for decoding
+     * @return deserialized record
+     */
+    public static <T extends SpecificRecord> AvroDeserializationSchema<T> forSpecific(
+            Class<T> tClass, AvroEncoding encoding) {
+        return new AvroDeserializationSchema<>(tClass, null, encoding);
     }
-  }
 
-  @Override
-  public boolean isEndOfStream(T nextElement) {
-    return false;
-  }
+    private static final long serialVersionUID = -6766681879020862312L;
 
-  @Override
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public TypeInformation<T> getProducedType() {
-    if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
-      return new AvroTypeInfo(recordClazz);
-    } else {
-      return (TypeInformation<T>) new GenericRecordAvroTypeInfo(this.reader);
+    /** Class to deserialize to. */
+    private final Class<T> recordClazz;
+
+    /** Schema in case of GenericRecord for serialization purpose. */
+    private final String schemaString;
+
+    /** Reader that deserializes byte array into a record. */
+    private transient GenericDatumReader<T> datumReader;
+
+    /** Input stream to read message from. */
+    private transient MutableByteArrayInputStream inputStream;
+
+    /** Config option for the deserialization approach to use. */
+    private final AvroEncoding encoding;
+
+    /** Avro decoder that decodes data. */
+    private transient Decoder decoder;
+
+    /** Avro schema for the reader. */
+    private transient Schema reader;
+
+    /**
+     * Creates a Avro deserialization schema.
+     *
+     * @param recordClazz class to which deserialize. Should be one of: {@link
+     *     org.apache.avro.specific.SpecificRecord}, {@link org.apache.avro.generic.GenericRecord}.
+     * @param reader reader's Avro schema. Should be provided if recordClazz is {@link
+     *     GenericRecord}
+     * @param encoding encoding approach to use. Identifies the Avro decoder class to use.
+     */
+    AvroDeserializationSchema(
+            Class<T> recordClazz, @Nullable Schema reader, AvroEncoding encoding) {
+        Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
+        this.recordClazz = recordClazz;
+        this.reader = reader;
+        if (reader != null) {
+            this.schemaString = reader.toString();
+        } else {
+            this.schemaString = null;
+        }
+        this.encoding = encoding;
     }
-  }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    GenericDatumReader<T> getDatumReader() {
+        return datumReader;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    AvroDeserializationSchema<?> that = (AvroDeserializationSchema<?>) o;
-    return recordClazz.equals(that.recordClazz) && Objects.equals(reader, that.reader);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(recordClazz, reader);
-  }
+    Schema getReaderSchema() {
+        return reader;
+    }
+
+    MutableByteArrayInputStream getInputStream() {
+        return inputStream;
+    }
+
+    Decoder getDecoder() {
+        return decoder;
+    }
+
+    AvroEncoding getEncoding() {
+        return encoding;
+    }
+
+    @Override
+    public T deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
+        // read record
+        checkAvroInitialized();
+        inputStream.setBuffer(message);
+        Schema readerSchema = getReaderSchema();
+        GenericDatumReader<T> datumReader = getDatumReader();
+
+        datumReader.setSchema(readerSchema);
+
+        if (encoding == AvroEncoding.JSON) {
+            ((JsonDecoder) this.decoder).configure(inputStream);
+        }
+
+        try {
+            return datumReader.read(null, decoder);
+        } catch (Exception e) {
+            /*
+             * If the deserialization fails, {@code datumReader} has to be reset, because {@code Decoder} will remain in an
+             * inconsistent state, which will make subsequent valid deserialization attempts to fail.
+             */
+            this.datumReader = null;
+            throw e;
+        }
+    }
+
+    void checkAvroInitialized() throws IOException {
+        if (datumReader != null) {
+            return;
+        }
+
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+            @SuppressWarnings("unchecked")
+            SpecificData specificData =
+                    AvroFactory.getSpecificDataForClass(
+                            (Class<? extends SpecificData>) recordClazz, cl);
+            this.datumReader = new SpecificDatumReader<>(specificData);
+            this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
+        } else {
+            this.reader = new Schema.Parser().parse(schemaString);
+            GenericData genericData = new GenericData(cl);
+            this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
+        }
+
+        this.inputStream = new MutableByteArrayInputStream();
+
+        if (encoding == AvroEncoding.JSON) {
+            this.decoder = DecoderFactory.get().jsonDecoder(getReaderSchema(), inputStream);
+        } else {
+            this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(T nextElement) {
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public TypeInformation<T> getProducedType() {
+        if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+            return new AvroTypeInfo(recordClazz);
+        } else {
+            return (TypeInformation<T>) new GenericRecordAvroTypeInfo(this.reader);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AvroDeserializationSchema<?> that = (AvroDeserializationSchema<?>) o;
+        return recordClazz.equals(that.recordClazz) && Objects.equals(reader, that.reader);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(recordClazz, reader);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -78,37 +78,39 @@
   </distributionManagement>
 
   <properties>
-    <!-- Plugin versions -->
-    <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
-    <git-code-format-maven-plugin.version>5.3</git-code-format-maven-plugin.version>
-    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <surefire-plugin.version>3.5.3</surefire-plugin.version>
-    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-    <docker-compose-plugin.version>5.0.0</docker-compose-plugin.version>
-    <sortpom.plugin.version>4.0.0</sortpom.plugin.version>
-    <exec.plugin.version>3.5.1</exec.plugin.version>
-    <build-helper-maven-plugin.verison>3.6.1</build-helper-maven-plugin.verison>
-
-    <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.24.3</log4j.version>
-    <feign.version>13.5</feign.version>
-    <picocli.version>4.7.7</picocli.version>
-    <flink.version>1.19.2</flink.version>
-    <postgres.version>42.7.6</postgres.version>
-    <testcontainers.version>1.21.1</testcontainers.version>
-    <kafka.version>3.2.0-1.19</kafka.version>
-    <jdbc.version>3.2.0-1.19</jdbc.version>
-    <lombok.version>1.18.38</lombok.version>
-    <auto.service.version>1.1.1</auto.service.version>
-    <mockito.version>5.18.0</mockito.version>
-    <assertj.version>3.27.3</assertj.version>
-
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+
+    <!-- Dependency versions -->
+    <assertj.version>3.27.3</assertj.version>
+    <auto.service.version>1.1.1</auto.service.version>
+    <feign.version>13.5</feign.version>
+    <flink.version>1.19.2</flink.version>
+    <jdbc.version>3.2.0-1.19</jdbc.version>
+    <junit.version>5.13.1</junit.version>
+    <kafka.version>3.2.0-1.19</kafka.version>
+    <log4j.version>2.24.3</log4j.version>
+    <lombok.version>1.18.38</lombok.version>
+    <mockito.version>5.18.0</mockito.version>
+    <picocli.version>4.7.7</picocli.version>
+    <postgres.version>42.7.6</postgres.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <testcontainers.version>1.21.1</testcontainers.version>
+
+    <!-- Plugin versions -->
+    <build-helper-maven-plugin.verison>3.6.1</build-helper-maven-plugin.verison>
+    <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+    <docker-compose-maven-plugin.version>5.0.0</docker-compose-maven-plugin.version>
+    <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
+    <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+    <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+    <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <spotless-maven-plugin>2.44.5</spotless-maven-plugin>
+    <sundr-maven-plugin.version>0.200.4</sundr-maven-plugin.version>
 
     <!-- Example: skip install hooks, etc. -->
     <gcf.skipInstallHooks>true</gcf.skipInstallHooks>
@@ -119,7 +121,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.13.0</version>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -139,7 +141,7 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- General Dependencies -->
+    <!-- General dependencies -->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -147,7 +149,7 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- common test infra-->
+    <!-- Common test dependencies-->
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
@@ -177,54 +179,116 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.sundr</groupId>
+          <artifactId>sundr-maven-plugin</artifactId>
+          <version>${sundr-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven-gpg-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.verison}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
-        <groupId>com.cosium.code</groupId>
-        <artifactId>git-code-format-maven-plugin</artifactId>
-        <version>${git-code-format-maven-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.cosium.code</groupId>
-            <artifactId>google-java-format</artifactId>
-            <version>${git-code-format-maven-plugin.version}</version>
-          </dependency>
-        </dependencies>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <!-- DataSQRL code style -->
+          <java>
+            <excludes>
+              <exclude>**/org/apache/flink/**/*.java</exclude>
+            </excludes>
+            <googleJavaFormat/>
+            <removeUnusedImports/>
+          </java>
+          <!-- Apache Flink code style -->
+          <java>
+            <includes>
+              <include>**/org/apache/flink/**/*.java</include>
+            </includes>
+            <googleJavaFormat>
+              <version>1.8</version>
+              <style>AOSP</style>
+            </googleJavaFormat>
+            <!-- \# refers to the static imports -->
+            <importOrder>
+              <order>org.apache.flink,org.apache.flink.shaded,,javax,java,scala,\#</order>
+            </importOrder>
+            <removeUnusedImports/>
+          </java>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <lineSeparator>\n</lineSeparator>
+              <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
+            </sortPom>
+          </pom>
+        </configuration>
         <executions>
-          <!-- On commit, format the modified files -->
           <execution>
-            <id>install-formatter-hook</id>
+            <id>spotless-check</id>
             <goals>
-              <goal>install-hooks</goal>
+              <goal>check</goal>
             </goals>
-            <!-- inherited = false means it won't re-run in submodules if not desired -->
-            <inherited>false</inherited>
-          </execution>
-          <!-- On Maven verify, fail if code is not formatted -->
-          <execution>
-            <id>validate-code-format</id>
-            <goals>
-              <goal>validate-code-format</goal>
-            </goals>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
 
       <plugin>
-        <groupId>com.github.ekryd.sortpom</groupId>
-        <artifactId>sortpom-maven-plugin</artifactId>
-        <version>${sortpom.plugin.version}</version>
-        <configuration>
-          <keepBlankLines>true</keepBlankLines>
-          <lineSeparator>\n</lineSeparator>
-          <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
-          <createBackupFile>false</createBackupFile>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${license-maven-plugin.version}</version>
         <configuration>
           <properties>
             <owner>DataSQRL</owner>
@@ -264,7 +328,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${maven-enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>ban-sqrl-dependencies</id>
@@ -290,7 +353,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
         <configuration>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -301,7 +363,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -341,7 +403,6 @@
       <plugin>
         <groupId>io.sundr</groupId>
         <artifactId>sundr-maven-plugin</artifactId>
-        <version>0.200.4</version>
         <inherited>false</inherited>
         <configuration>
           <boms>
@@ -390,26 +451,13 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>com.cosium.code</groupId>
-            <artifactId>git-code-format-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>format-code</id>
-                <goals>
-                  <goal>format-code</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.github.ekryd.sortpom</groupId>
-            <artifactId>sortpom-maven-plugin</artifactId>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>format</id>
                 <goals>
-                  <goal>sort</goal>
+                  <goal>apply</goal>
                 </goals>
                 <phase>initialize</phase>
               </execution>
@@ -446,7 +494,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>${build-helper-maven-plugin.verison}</version>
             <executions>
               <execution>
                 <id>add-flink-1.20+-specific-source</id>
@@ -498,7 +545,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>${maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -512,7 +558,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>${maven-source-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -577,7 +622,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>${build-helper-maven-plugin.verison}</version>
             <executions>
               <execution>
                 <id>add-source</id>
@@ -634,7 +678,6 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,7 @@
 
               <properties>
                 <license.skip>true</license.skip>
+                <spotless.check.skip>true</spotless.check.skip>
               </properties>
 
               <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,6 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <spotless-maven-plugin>2.44.5</spotless-maven-plugin>
     <sundr-maven-plugin.version>0.200.4</sundr-maven-plugin.version>
-
-    <!-- Example: skip install hooks, etc. -->
-    <gcf.skipInstallHooks>true</gcf.skipInstallHooks>
   </properties>
 
   <dependencyManagement>
@@ -244,6 +241,11 @@
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+            </sortPom>
+          </pom>
           <!-- DataSQRL code style -->
           <java>
             <excludes>
@@ -267,13 +269,6 @@
             </importOrder>
             <removeUnusedImports/>
           </java>
-          <pom>
-            <sortPom>
-              <expandEmptyElements>false</expandEmptyElements>
-              <lineSeparator>\n</lineSeparator>
-              <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
-            </sortPom>
-          </pom>
         </configuration>
         <executions>
           <execution>
@@ -396,6 +391,7 @@
           </projectRules>
           <projectExtraProperties>
             <license.skip>true</license.skip>
+            <spotless.check.skip>true</spotless.check.skip>
           </projectExtraProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <testcontainers.version>1.21.1</testcontainers.version>
 
     <!-- Plugin versions -->
-    <build-helper-maven-plugin.verison>3.6.1</build-helper-maven-plugin.verison>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     <docker-compose-maven-plugin.version>5.0.0</docker-compose-maven-plugin.version>
     <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
@@ -226,7 +226,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${build-helper-maven-plugin.verison}</version>
+          <version>${build-helper-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
Also did some minor `pom.xml` housekeeping, added `pluginManagement`, reordered property groups, and removed duplicated `lombok` dependency.

> [!IMPORTANT]  
> The java class changes are only code format, it contains the same logic.

Resolves #135 