### PR TITLE
Rationalize Lombok usage in the project

### DIFF
--- a/flink-sql-runner/src/main/java/com/datasqrl/EnvVarUtils.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/EnvVarUtils.java
@@ -21,42 +21,39 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@UtilityClass
-public class EnvironmentVariablesUtils {
+class EnvVarUtils {
 
   private static final Pattern ENVIRONMENT_VARIABLE_PATTERN = Pattern.compile("\\$\\{(.*?)\\}");
 
-  public static String replaceWithEnv(String command) {
+  static String replaceWithEnv(String command) {
     return replaceWithEnv(command, System.getenv());
   }
 
-  public static String replaceWithEnv(String command, Map<String, String> envVariables) {
-    var substitutedStr = command;
-    var result = new StringBuffer();
+  static String replaceWithEnv(String command, Map<String, String> envVariables) {
+    var res = new StringBuffer();
     // First pass to replace environment variables
-    var matcher = ENVIRONMENT_VARIABLE_PATTERN.matcher(substitutedStr);
+    var matcher = ENVIRONMENT_VARIABLE_PATTERN.matcher(command);
     while (matcher.find()) {
       var key = matcher.group(1);
       var envValue = envVariables.get(key);
       if (envValue == null) {
         throw new IllegalStateException(String.format("Missing environment variable: %s", key));
       }
-      matcher.appendReplacement(result, Matcher.quoteReplacement(envValue));
+      matcher.appendReplacement(res, Matcher.quoteReplacement(envValue));
     }
-    matcher.appendTail(result);
+    matcher.appendTail(res);
 
-    return result.toString();
+    return res.toString();
   }
 
-  public Set<String> validateEnvironmentVariables(String script) {
+  static Set<String> validateEnvironmentVariables(String script) {
     return validateEnvironmentVariables(System.getenv(), script);
   }
 
-  public Set<String> validateEnvironmentVariables(Map<String, String> envVariables, String script) {
+  static Set<String> validateEnvironmentVariables(Map<String, String> envVariables, String script) {
     var matcher = ENVIRONMENT_VARIABLE_PATTERN.matcher(script);
 
     Set<String> scriptEnvironmentVariables = new TreeSet<>();
@@ -71,5 +68,9 @@ public class EnvironmentVariablesUtils {
 
     scriptEnvironmentVariables.removeAll(envVariables.keySet());
     return Collections.unmodifiableSet(scriptEnvironmentVariables);
+  }
+
+  private EnvVarUtils() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/flink-sql-runner/src/main/java/com/datasqrl/FlinkMain.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/FlinkMain.java
@@ -138,8 +138,7 @@ public class FlinkMain {
       // Single SQL file mode
       var script = FileUtils.readFileUtf8(new File(sqlFile));
 
-      var missingEnvironmentVariables =
-          EnvironmentVariablesUtils.validateEnvironmentVariables(script);
+      var missingEnvironmentVariables = EnvVarUtils.validateEnvironmentVariables(script);
       if (!missingEnvironmentVariables.isEmpty()) {
         throw new IllegalStateException(
             String.format(
@@ -154,8 +153,7 @@ public class FlinkMain {
       // Compiled plan JSON file
       var planJson = FileUtils.readFileUtf8(new File(planFile));
 
-      var missingEnvironmentVariables =
-          EnvironmentVariablesUtils.validateEnvironmentVariables(planJson);
+      var missingEnvironmentVariables = EnvVarUtils.validateEnvironmentVariables(planJson);
       if (!missingEnvironmentVariables.isEmpty()) {
         throw new IllegalStateException(
             String.format(

--- a/flink-sql-runner/src/main/java/com/datasqrl/SqlExecutor.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/SqlExecutor.java
@@ -114,7 +114,7 @@ class SqlExecutor {
       } else {
         System.out.println(statement);
         log.info("Executing statement:\n{}", statement);
-        tableResult = tableEnv.executeSql(EnvironmentVariablesUtils.replaceWithEnv(statement));
+        tableResult = tableEnv.executeSql(EnvVarUtils.replaceWithEnv(statement));
       }
     } catch (Exception e) {
       e.addSuppressed(new RuntimeException("Error while executing stmt: " + statement));

--- a/flink-sql-runner/src/main/java/com/datasqrl/SqlUtils.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/SqlUtils.java
@@ -17,10 +17,8 @@ package com.datasqrl;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.experimental.UtilityClass;
 
 /** Utility class for parsing SQL scripts. */
-@UtilityClass
 class SqlUtils {
 
   private static final String STATEMENT_DELIMITER = ";"; // a statement should end with `;`
@@ -39,7 +37,7 @@ class SqlUtils {
    * @param script The SQL script content.
    * @return A list of individual SQL statements.
    */
-  public static List<String> parseStatements(String script) {
+  static List<String> parseStatements(String script) {
     var formatted =
         formatSqlFile(script)
             .replaceAll(BEGIN_CERTIFICATE, ESCAPED_BEGIN_CERTIFICATE)
@@ -82,7 +80,7 @@ class SqlUtils {
    * @param content The SQL file content.
    * @return Formatted SQL content.
    */
-  public static String formatSqlFile(String content) {
+  static String formatSqlFile(String content) {
     var trimmed = content.trim();
     var formatted = new StringBuilder();
     formatted.append(trimmed);
@@ -91,5 +89,9 @@ class SqlUtils {
     }
     formatted.append(LINE_DELIMITER);
     return formatted.toString();
+  }
+
+  private SqlUtils() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/flink-sql-runner/src/test/java/com/datasqrl/CommandLineUtil.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/CommandLineUtil.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -28,7 +27,6 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 
 @Slf4j
-@UtilityClass
 public class CommandLineUtil {
 
   public static String execute(String command) throws ExecuteException {
@@ -71,5 +69,9 @@ public class CommandLineUtil {
       }
       throw new RuntimeException(e);
     }
+  }
+
+  private CommandLineUtil() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/flink-sql-runner/src/test/java/com/datasqrl/EnvironmentVariablesUtilsTest.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/EnvironmentVariablesUtilsTest.java
@@ -36,7 +36,7 @@ class EnvironmentVariablesUtilsTest {
         Map.of(
             "USER", "John",
             "PATH", "/usr/bin");
-    var result = EnvironmentVariablesUtils.replaceWithEnv(command, envVariables);
+    var result = EnvVarUtils.replaceWithEnv(command, envVariables);
     assertThat(result).isEqualTo(expected);
   }
 
@@ -48,7 +48,7 @@ class EnvironmentVariablesUtilsTest {
   })
   void givenMissingEnvVariables_whenReplaceWithEnv_thenThrowException(String command) {
     Map<String, String> envVariables = Map.of(); // Empty map to simulate missing variables
-    assertThatThrownBy(() -> EnvironmentVariablesUtils.replaceWithEnv(command, envVariables))
+    assertThatThrownBy(() -> EnvVarUtils.replaceWithEnv(command, envVariables))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Missing environment variable");
   }
@@ -64,7 +64,7 @@ class EnvironmentVariablesUtilsTest {
         Map.of(
             "USER", "John",
             "NAME", "exists");
-    assertThatThrownBy(() -> EnvironmentVariablesUtils.replaceWithEnv(command, envVariables))
+    assertThatThrownBy(() -> EnvVarUtils.replaceWithEnv(command, envVariables))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Missing environment variable: USER_NAME");
   }
@@ -79,7 +79,7 @@ class EnvironmentVariablesUtilsTest {
             "VAR2", "2",
             "USER", "admin",
             "HOME", "/home/admin");
-    var missingVars = EnvironmentVariablesUtils.validateEnvironmentVariables(envVariables, script);
+    var missingVars = EnvVarUtils.validateEnvironmentVariables(envVariables, script);
     assertThat(missingVars).isEmpty();
   }
 
@@ -96,7 +96,7 @@ class EnvironmentVariablesUtilsTest {
             "VAR1", "1",
             "USER", "admin",
             "HOME", "/home/admin");
-    var missingVars = EnvironmentVariablesUtils.validateEnvironmentVariables(envVariables, script);
+    var missingVars = EnvVarUtils.validateEnvironmentVariables(envVariables, script);
     assertThat(missingVars).containsExactlyInAnyOrder(expectedMissing.split(","));
   }
 
@@ -111,7 +111,7 @@ class EnvironmentVariablesUtilsTest {
         Map.of(
             "USER", "admin",
             "NAME", "admin");
-    var missingVars = EnvironmentVariablesUtils.validateEnvironmentVariables(envVariables, script);
+    var missingVars = EnvVarUtils.validateEnvironmentVariables(envVariables, script);
     assertThat(missingVars)
         .containsExactly("USER_NAME"); // Ensure only USERNAME is reported missing
   }

--- a/functions/functions-common/src/main/java/com/datasqrl/flinkrunner/functions/FlinkTypeUtil.java
+++ b/functions/functions-common/src/main/java/com/datasqrl/flinkrunner/functions/FlinkTypeUtil.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.Singular;
 import lombok.SneakyThrows;
-import lombok.Value;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.ArgumentCount;
@@ -74,14 +74,14 @@ public class FlinkTypeUtil {
     }
   }
 
-  @Value
   @Builder
-  public static class VariableArguments implements InputTypeStrategy {
+  @Getter
+  public static final class VariableArguments implements InputTypeStrategy {
 
-    @Singular List<DataType> staticTypes;
-    DataType variableType;
-    int minVariableArguments;
-    int maxVariableArguments;
+    @Singular private final List<DataType> staticTypes;
+    private final DataType variableType;
+    private final int minVariableArguments;
+    private final int maxVariableArguments;
 
     @Override
     public ArgumentCount getArgumentCount() {

--- a/types/json-type/src/main/java/com/datasqrl/flinkrunner/functions/json/ArrayAgg.java
+++ b/types/json-type/src/main/java/com/datasqrl/flinkrunner/functions/json/ArrayAgg.java
@@ -16,15 +16,17 @@
 package com.datasqrl.flinkrunner.functions.json;
 
 import java.util.List;
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.annotation.DataTypeHint;
 
-@Value
-public class ArrayAgg {
+@AllArgsConstructor
+@Getter
+public final class ArrayAgg {
 
-  @DataTypeHint(value = "RAW")
-  private List<JsonNode> objects;
+  @DataTypeHint("RAW")
+  private final List<JsonNode> objects;
 
   public void add(JsonNode value) {
     objects.add(value);

--- a/types/json-type/src/main/java/com/datasqrl/flinkrunner/functions/json/ObjectAgg.java
+++ b/types/json-type/src/main/java/com/datasqrl/flinkrunner/functions/json/ObjectAgg.java
@@ -16,17 +16,17 @@
 package com.datasqrl.flinkrunner.functions.json;
 
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Value;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.annotation.DataTypeHint;
 
-@Value
-public class ObjectAgg {
+@AllArgsConstructor
+@Getter
+public final class ObjectAgg {
 
-  @DataTypeHint(value = "RAW")
-  @Getter
-  Map<String, JsonNode> objects;
+  @DataTypeHint("RAW")
+  private final Map<String, JsonNode> objects;
 
   public void add(String key, JsonNode value) {
     if (key != null) {


### PR DESCRIPTION
Resolves #134. Based on the issue definition, the applied changes:
- removed `UtilityClass` usage
- removed `Value` usage

Adapted the vanilla Java code accordingly.