### PR TITLE
Sort and cleanup POM files

### DIFF
--- a/connectors/kafka-safe-connector/pom.xml
+++ b/connectors/kafka-safe-connector/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -27,30 +26,9 @@
   </parent>
 
   <artifactId>kafka-safe-connector</artifactId>
-  <description>Kafka connector with deserialization error handling</description>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-core</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
+    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-api-java-bridge</artifactId>
@@ -61,19 +39,8 @@
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-kafka</artifactId>
-      <version>${kafka.version}</version>
+      <version>${kafka.conn.version}</version>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -35,11 +34,18 @@
   </modules>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-base</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/connectors/postgresql-connector/pom.xml
+++ b/connectors/postgresql-connector/pom.xml
@@ -18,6 +18,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.datasqrl.flinkrunner</groupId>
     <artifactId>connectors</artifactId>
@@ -25,80 +26,87 @@
   </parent>
 
   <artifactId>postgresql-connector</artifactId>
-  <description>Jdbc sink for flink 1.19</description>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-jdbc</artifactId>
-      <version>3.2.0-1.19</version>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${postgres.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-runtime</artifactId>
-      <version>${flink.version}</version>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-common</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-json</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-vector</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>flexible-json-format</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-utils</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-csv</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-json</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-vector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>flexible-json-format</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-connector-jdbc</artifactId>
+      <version>${jdbc.conn.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgres.version}</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-runtime</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-planner_2.12</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-test-utils</artifactId>
       <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -29,29 +28,26 @@
   <artifactId>flink-sql-runner</artifactId>
 
   <dependencies>
+    <!-- Provided -->
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java</artifactId>
+      <artifactId>flink-table-api-java-bridge</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java</artifactId>
+      <artifactId>flink-table-planner-loader</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-planner_2.12</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime-web</artifactId>
-      <version>${flink.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- Add logging framework, to produce console output when running in the IDE. -->
@@ -61,109 +57,89 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Compile -->
+    <!-- Custom Connectors -->
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
-      <scope>runtime</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>kafka-safe-connector</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli</artifactId>
-      <version>${picocli.version}</version>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>postgresql-connector</artifactId>
+      <version>${project.version}</version>
     </dependency>
+
+    <!-- Custom Formats -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-test-utils</artifactId>
-      <version>${flink.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>flexible-csv-format</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>com.nextbreakpoint</groupId>
-      <artifactId>com.nextbreakpoint.flink.client</artifactId>
-      <version>1.1.4</version>
-      <scope>test</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>flexible-json-format</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- StdLib -->
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-commons</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.3.0</version>
-      <scope>test</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-json</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-      <version>1.5.0</version>
-      <scope>test</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-vector</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
-    <!-- JDBI -->
     <dependency>
-      <groupId>org.jdbi</groupId>
-      <artifactId>jdbi3-core</artifactId>
-      <version>3.49.4</version>
-      <scope>test</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-text</artifactId>
+      <version>${project.version}</version>
     </dependency>
+
     <dependency>
-      <groupId>org.jdbi</groupId>
-      <artifactId>jdbi3-sqlobject</artifactId>
-      <version>3.49.4</version>
-      <scope>test</scope>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-math</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-openai</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-kafka</artifactId>
-      <version>${kafka.version}</version>
+      <version>${kafka.conn.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-jdbc</artifactId>
-      <version>${jdbc.version}</version>
+      <version>${jdbc.conn.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-avro-confluent-registry</artifactId>
       <version>${flink.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-s3-fs-hadoop</artifactId>
@@ -171,29 +147,45 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>udf-sample</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${picocli.version}</version>
     </dependency>
+
+    <!-- Runtime -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>system-functions-sample</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>udf-sample</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>org.jacoco.core</artifactId>
-      <version>0.8.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>org.jacoco.agent</artifactId>
-      <version>0.8.13</version>
-      <classifier>runtime</classifier>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>system-functions-sample</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -205,62 +197,82 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- project dependencies-->
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>flexible-csv-format</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime-web</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>flexible-json-format</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-test-utils</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-utils</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
+      <groupId>com.nextbreakpoint</groupId>
+      <artifactId>com.nextbreakpoint.flink.client</artifactId>
+      <version>${nextbreakpoint.flink.client.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-commons</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-json</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>${commons-exec.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-vector</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>kafka-safe-connector</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>postgresql-connector</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.jdbi</groupId>
+      <artifactId>jdbi3-core</artifactId>
+      <version>${jdbi3.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-text</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.jdbi</groupId>
+      <artifactId>jdbi3-sqlobject</artifactId>
+      <version>${jdbi3.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-math</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.core</artifactId>
+      <version>${jacoco.version}</version>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-openai</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>${jacoco.version}</version>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/formats/flexible-csv-format/pom.xml
+++ b/formats/flexible-csv-format/pom.xml
@@ -17,8 +17,8 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.datasqrl.flinkrunner</groupId>
     <artifactId>formats</artifactId>
@@ -27,30 +27,13 @@
 
   <artifactId>flexible-csv-format</artifactId>
 
-  <description>Flexible csv format</description>
-
   <dependencies>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-json</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
+    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-csv</artifactId>
       <version>${flink.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
   </dependencies>
-
 </project>

--- a/formats/flexible-json-format/pom.xml
+++ b/formats/flexible-json-format/pom.xml
@@ -17,8 +17,8 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.datasqrl.flinkrunner</groupId>
     <artifactId>formats</artifactId>
@@ -26,32 +26,21 @@
   </parent>
 
   <artifactId>flexible-json-format</artifactId>
-  <description>Flexible json format</description>
 
   <dependencies>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-json</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
+    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-json</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
-  </dependencies>
 
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/formats/pom.xml
+++ b/formats/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -34,4 +33,19 @@
     <module>flexible-json-format</module>
   </modules>
 
+  <dependencies>
+    <!-- Provided -->
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-common</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,13 @@
       <email>daniel@datasqrl.com</email>
       <url>https://github.com/henneberger</url>
     </developer>
+
     <developer>
       <name>Marvin Froeder</name>
       <email>marvin@datasqrl.com</email>
       <url>https://github.com/velo</url>
     </developer>
+
     <developer>
       <name>Ferenc Csaky</name>
       <email>ferenc@datasqrl.com</email>
@@ -81,17 +83,26 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
+    <!-- Flink versions -->
+    <flink.version>1.19.2</flink.version>
+    <jdbc.conn.version>3.2.0-1.19</jdbc.conn.version>
+    <kafka.conn.version>3.2.0-1.19</kafka.conn.version>
+
     <!-- Dependency versions -->
     <assertj.version>3.27.3</assertj.version>
     <auto.service.version>1.1.1</auto.service.version>
+    <awaitility.version>4.3.0</awaitility.version>
+    <commons-exec.version>1.5.0</commons-exec.version>
+    <commons-math3.version>3.6.1</commons-math3.version>
     <feign.version>13.5</feign.version>
-    <flink.version>1.19.2</flink.version>
-    <jdbc.version>3.2.0-1.19</jdbc.version>
+    <jacoco.version>0.8.13</jacoco.version>
+    <jdbi3.version>3.49.5</jdbi3.version>
+    <json-path.version>2.9.0</json-path.version>
     <junit.version>5.13.1</junit.version>
-    <kafka.version>3.2.0-1.19</kafka.version>
     <log4j.version>2.24.3</log4j.version>
     <lombok.version>1.18.38</lombok.version>
     <mockito.version>5.18.0</mockito.version>
+    <nextbreakpoint.flink.client.version>1.1.4</nextbreakpoint.flink.client.version>
     <picocli.version>4.7.7</picocli.version>
     <postgres.version>42.7.7</postgres.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -120,6 +131,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
@@ -127,6 +139,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
@@ -136,7 +149,7 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- General dependencies -->
+    <!-- Common provided dependencies -->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -150,33 +163,39 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
@@ -193,21 +212,25 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless-maven-plugin}</version>
         </plugin>
+
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>${license-maven-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>io.sundr</groupId>
           <artifactId>sundr-maven-plugin</artifactId>
           <version>${sundr-maven-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
@@ -218,26 +241,31 @@
           <artifactId>maven-gpg-plugin</artifactId>
           <version>${maven-gpg-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>${maven-source-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
@@ -452,89 +480,44 @@
   </build>
 
   <profiles>
-    <!-- Useful profile for local dev (forces code format, etc.) -->
+    <!-- Skip code format, license checks, tests, and enforced rules -->
     <profile>
-      <id>dev</id>
+      <id>fast</id>
+      <activation>
+        <property>
+          <name>fast</name>
+        </property>
+      </activation>
       <properties>
-        <gcf.skipInstallHooks>false</gcf.skipInstallHooks>
-        <flink.version>1.19.2</flink.version>
-        <jdbc.version>3.2.0-1.19</jdbc.version>
-        <kafka.version>3.2.0-1.19</kafka.version>
-        <flink-base-image>1.19.2-scala_2.12-java17</flink-base-image>
+        <skipTests>true</skipTests>
+        <enforcer.skip>true</enforcer.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <license.skip>true</license.skip>
+        <spotless.check.skip>true</spotless.check.skip>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>format</id>
-                <goals>
-                  <goal>apply</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>format</id>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
-    <!--  Flink specific profiles  -->
+    <!-- Flink specific profiles -->
     <profile>
       <id>flink-2.0</id>
       <properties>
-        <flink.version>2.0-preview1</flink.version>
-        <jdbc.version>3.2.0-1.19</jdbc.version>
-        <kafka.version>3.2.0-1.19</kafka.version>
-        <flink-base-image>2.0-preview1-scala_2.12-java17</flink-base-image>
+        <flink.version>2.0.0</flink.version>
+        <jdbc.conn.version>3.2.0-1.19</jdbc.conn.version>
+        <kafka.conn.version>3.2.0-1.19</kafka.conn.version>
+        <flink-base-image>2.0.0-scala_2.12-java17</flink-base-image>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>add-flink-1.20+-specific-source</id>
-                <goals>
-                  <goal>add-source</goal>
-                </goals>
-                <phase>generate-sources</phase>
-                <configuration>
-                  <sources>
-                    <source>${basedir}/src/main/flink120+</source>
-                  </sources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
+
     <profile>
       <id>flink-1.20</id>
       <properties>
         <flink.version>1.20.1</flink.version>
-        <jdbc.version>3.2.0-1.19</jdbc.version>
-        <kafka.version>3.2.0-1.19</kafka.version>
-        <flink-base-image>1.20.0-scala_2.12-java17</flink-base-image>
+        <jdbc.conn.version>3.2.0-1.19</jdbc.conn.version>
+        <kafka.conn.version>3.2.0-1.19</kafka.conn.version>
+        <flink-base-image>1.20.1-scala_2.12-java17</flink-base-image>
       </properties>
     </profile>
+
     <profile>
       <id>flink-1.19</id>
       <activation>
@@ -542,8 +525,8 @@
       </activation>
       <properties>
         <flink.version>1.19.2</flink.version>
-        <jdbc.version>3.2.0-1.19</jdbc.version>
-        <kafka.version>3.2.0-1.19</kafka.version>
+        <jdbc.conn.version>3.2.0-1.19</jdbc.conn.version>
+        <kafka.conn.version>3.2.0-1.19</kafka.conn.version>
         <flink-base-image>1.19.2-scala_2.12-java17</flink-base-image>
       </properties>
     </profile>
@@ -551,9 +534,6 @@
     <!-- Extra tasks only meant to be executed by CI -->
     <profile>
       <id>ci</id>
-      <properties>
-        <gcf.skip>true</gcf.skip>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -611,23 +591,7 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <!-- just compile, skip all other checks -->
-      <id>fast</id>
-      <activation>
-        <property>
-          <name>fast</name>
-        </property>
-      </activation>
-      <properties>
-        <skipTests>true</skipTests>
-        <enforcer.skip>true</enforcer.skip>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <gcf.skip>true</gcf.skip>
-        <license.skip>true</license.skip>
-        <spotless.check.skip>true</spotless.check.skip>
-      </properties>
-    </profile>
+
     <profile>
       <!-- helper profile to proper configure eclipse -->
       <id>m2e</id>

--- a/stdlib/pom.xml
+++ b/stdlib/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -39,4 +38,18 @@
     <module>stdlib-utils</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-common</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/stdlib/stdlib-commons/pom.xml
+++ b/stdlib/stdlib-commons/pom.xml
@@ -28,20 +28,11 @@
   <artifactId>stdlib-commons</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/stdlib/stdlib-json/pom.xml
+++ b/stdlib/stdlib-json/pom.xml
@@ -28,32 +28,26 @@
   <artifactId>stdlib-json</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
+      <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>stdlib-utils</artifactId>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-runtime</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>stdlib-utils</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
+
+    <!-- Compile -->
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
+      <version>${json-path.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/stdlib/stdlib-math/pom.xml
+++ b/stdlib/stdlib-math/pom.xml
@@ -28,27 +28,19 @@
   <artifactId>stdlib-math</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
-      <version>3.6.1</version>
+      <version>${commons-math3.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/stdlib/stdlib-openai/pom.xml
+++ b/stdlib/stdlib-openai/pom.xml
@@ -28,24 +28,16 @@
   <artifactId>stdlib-openai</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-vector</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/stdlib/stdlib-text/pom.xml
+++ b/stdlib/stdlib-text/pom.xml
@@ -29,18 +29,9 @@
   <description>Text functions for Flink</description>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/stdlib/stdlib-utils/pom.xml
+++ b/stdlib/stdlib-utils/pom.xml
@@ -26,17 +26,4 @@
   </parent>
 
   <artifactId>stdlib-utils</artifactId>
-
-  <dependencies>
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
 </project>

--- a/stdlib/stdlib-vector/pom.xml
+++ b/stdlib/stdlib-vector/pom.xml
@@ -28,27 +28,20 @@
   <artifactId>stdlib-vector</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Compile -->
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>${commons-math3.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -17,7 +17,6 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/testing/system-functions-sample/pom.xml
+++ b/testing/system-functions-sample/pom.xml
@@ -28,18 +28,22 @@
   <artifactId>system-functions-sample</artifactId>
 
   <dependencies>
+    <!-- Provided -->
     <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-table-common</artifactId>
-      <version>1.19.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>stdlib-utils</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-common</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Compile -->
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>

--- a/testing/udf-sample/pom.xml
+++ b/testing/udf-sample/pom.xml
@@ -28,15 +28,18 @@
   <artifactId>udf-sample</artifactId>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-    </dependency>
+    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-api-java-bridge</artifactId>
-      <version>1.16.1</version>
+      <version>${flink.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- Compile -->
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Main points
- Introduce version prop to every version in root POM and use that in all modules
- Reduce duplications and define a dependency in a module as high in the hierarchy as it can be (e.g. put `auto-service`)
- Add empty lines between repeating tags to improve readability
- Introduce a dependency order based on scope (provided, compile, runtime, test in this order), order deps based on that, add comments to keep the sections more separate
- Rationalize some Flink dependencies, ditch ones that are not really used