### PR TITLE
Improve Docker container interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,25 +71,29 @@ This starts a full standalone Flink session cluster in one container:
 docker run --rm -it \
   -p 8081:8081 \
   -v "$PWD/sql-scripts":/flink/sql \
-  --name flink \
+  --name runner \
   datasqrl/flink-sql-runner:0.6.2-flink-1.19 \
-  bash -c "bin/start-cluster.sh && tail -f /dev/null"
+  cluster
 ```
 
 3\. Submit your SQL job
 In a separate terminal, run:
 
 ```bash
-docker exec -it flink flink run ./plugins/flink-sql-runner/flink-sql-runner.uber.jar --sqlfile /flink/sql/flink.sql
+docker exec -it runner flink run flink-sql-runner.jar --sqlfile /flink/sql/flink.sql
 ```
 
 The job will be submitted to the embedded JobManager and executed using the local TaskManager.
+
+> [!NOTE]  
+> The `flink-sql-runner.jar` is a symlink placed in the Flink root directory (`/opt/flink`) for easier access, but the actual file resides in its own plugin directory: `/opt/flink/plugins/flink-sql-runner`.
+> It is possible to add any Flink arguments or run any accessible JAR, just like with a vanilla `flink run` command.
 
 4\. Inspect output
 If your SQL uses the print connector as a sink, you can check logs via:
 
 ```bash
-docker exec -it flink bash -c "cat /opt/flink/log/$(ls /opt/flink/log | grep 'flink--taskexecutor' | grep '.out')"
+docker exec -it runner bash -c "cat /opt/flink/log/$(ls /opt/flink/log | grep 'flink--taskexecutor' | grep '.out')"
 ```
 
 Or use the Flink UI at http://localhost:8081 to monitor jobs.

--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -19,3 +19,9 @@ FROM flink:${flink-base-image}
 RUN mkdir -p /opt/flink/plugins/flink-sql-runner
 COPY flink-sql-runner.uber.jar /opt/flink/plugins/flink-sql-runner
 COPY stdlib-utils-${project.version}.jar /opt/flink/lib/stdlib-utils-${project.version}.jar
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh \
+  && ln -s /opt/flink/plugins/flink-sql-runner/flink-sql-runner.uber.jar /opt/flink/flink-sql-runner.jar
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/flink-sql-runner/src/main/docker/entrypoint.sh
+++ b/flink-sql-runner/src/main/docker/entrypoint.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2025 DataSQRL (contact@datasqrl.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+COMMAND_STANDALONE="standalone-job"
+COMMAND_HISTORY_SERVER="history-server"
+
+# If unspecified, the hostname of the container is taken as the JobManager address
+JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
+CONF_FILE_DIR="${FLINK_HOME}/conf"
+
+drop_privs_cmd() {
+    if [ $(id -u) != 0 ]; then
+        # Don't need to drop privs if EUID != 0
+        return
+    elif [ -x /sbin/su-exec ]; then
+        # Alpine
+        echo su-exec flink
+    else
+        # Others
+        echo gosu flink
+    fi
+}
+
+copy_plugins_if_required() {
+  if [ -z "$ENABLE_BUILT_IN_PLUGINS" ]; then
+    return 0
+  fi
+
+  echo "Enabling required built-in plugins"
+  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | tr ';' ' '); do
+    echo "Linking ${target_plugin} to plugin directory"
+    plugin_name=${target_plugin%.jar}
+
+    mkdir -p "${FLINK_HOME}/plugins/${plugin_name}"
+    if [ ! -e "${FLINK_HOME}/opt/${target_plugin}" ]; then
+      echo "Plugin ${target_plugin} does not exist. Exiting."
+      exit 1
+    else
+      ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"
+      echo "Successfully enabled ${target_plugin}"
+    fi
+  done
+}
+
+set_config_options() {
+    local config_parser_script="$FLINK_HOME/bin/config-parser-utils.sh"
+    local config_dir="$FLINK_HOME/conf"
+    local bin_dir="$FLINK_HOME/bin"
+    local lib_dir="$FLINK_HOME/lib"
+
+    local config_params=()
+
+    while [ $# -gt 0 ]; do
+        local key="$1"
+        local value="$2"
+
+        config_params+=("-D${key}=${value}")
+
+        shift 2
+    done
+
+    if [ "${#config_params[@]}" -gt 0 ]; then
+        "${config_parser_script}" "${config_dir}" "${bin_dir}" "${lib_dir}" "${config_params[@]}"
+    fi
+}
+
+prepare_configuration() {
+    local config_options=()
+
+    config_options+=("jobmanager.rpc.address" "${JOB_MANAGER_RPC_ADDRESS}")
+    config_options+=("blob.server.port" "6124")
+    config_options+=("query.server.port" "6125")
+
+    if [ -n "${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}" ]; then
+        config_options+=("taskmanager.numberOfTaskSlots" "${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}")
+    fi
+
+    if [ ${#config_options[@]} -ne 0 ]; then
+        set_config_options "${config_options[@]}"
+    fi
+
+    if [ -n "${FLINK_PROPERTIES}" ]; then
+        process_flink_properties "${FLINK_PROPERTIES}"
+    fi
+}
+
+process_flink_properties() {
+    local flink_properties_content=$1
+    local config_options=()
+
+    local OLD_IFS="$IFS"
+    IFS=$'\n'
+    for prop in $flink_properties_content; do
+        prop=$(echo $prop | tr -d '[:space:]')
+
+        if [ -z "$prop" ]; then
+            continue
+        fi
+
+        IFS=':' read -r key value <<< "$prop"
+
+        value=$(echo $value | envsubst)
+
+        config_options+=("$key" "$value")
+    done
+    IFS="$OLD_IFS"
+
+    if [ ${#config_options[@]} -ne 0 ]; then
+        set_config_options "${config_options[@]}"
+    fi
+}
+
+maybe_enable_jemalloc() {
+    if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
+        JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+        JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+        if [ -f "$JEMALLOC_PATH" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_PATH
+        elif [ -f "$JEMALLOC_FALLBACK" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_FALLBACK
+        else
+            if [ "$JEMALLOC_PATH" = "$JEMALLOC_FALLBACK" ]; then
+                MSG_PATH=$JEMALLOC_PATH
+            else
+                MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
+            fi
+            echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
+        fi
+    fi
+}
+
+maybe_enable_jemalloc
+
+copy_plugins_if_required
+
+prepare_configuration
+
+args=("$@")
+if [ "$1" = "help" ]; then
+    printf "Usage: $(basename "$0") (jobmanager|${COMMAND_STANDALONE}|taskmanager|${COMMAND_HISTORY_SERVER})\n"
+    printf "    Or $(basename "$0") help\n\n"
+    printf "By default, Flink image adopts jemalloc as default memory allocator. This behavior can be disabled by setting the 'DISABLE_JEMALLOC' environment variable to 'true'.\n"
+    exit 0
+elif [ "$1" = "jobmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_STANDALONE} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/standalone-job.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_HISTORY_SERVER} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting History Server"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/historyserver.sh" start-foreground "${args[@]}"
+elif [ "$1" = "taskmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Task Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground "${args[@]}"
+elif [ "$1" = "cluster" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Cluster"
+
+    exec bash -c "$(drop_privs_cmd) $FLINK_HOME/bin/start-cluster.sh; tail -f /dev/null"
+fi
+
+args=("${args[@]}")
+
+# Running command in pass-through mode
+exec $(drop_privs_cmd) "${args[@]}"


### PR DESCRIPTION
## Main changes
- Added the original Flink img entrypoint and expanded it with a `clsuter` option, that pretty much does the same as the previous manual start command
- Also created a symlink for the `flink-sql-runner` JAR into `FLINK_HOME`, so starting a job is also reequires less characters
- Adapted README

## Possible Idea
I wondered about adding a custom `flink-sql-runner` script and put it to `PATH` so one woul be able to do the following:
```bash
docker exec -it <container-name|id> flink-sql-runner --sqlfile <path-to-sql>
```
The reason I did not add it right away is the downside of this will make it impossible (or at least cumbersome) to pass Flink-specific arguments.