### PR TITLE
Refactor common runner code to not use 3rd party dependencies

### DIFF
--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
@@ -52,12 +51,12 @@ abstract class BaseRunner {
   TableResult run(Supplier<SqlExecutor> sqlExecutorSupplier) throws Exception {
     var sqlExecutor = sqlExecutorSupplier.get();
 
-    if (StringUtils.isNoneBlank(sqlFile, planFile)) {
+    if (StringUtils.isNotBlank(sqlFile) && StringUtils.isNotBlank(planFile)) {
       throw new IllegalArgumentException(
           "Provide either a SQL file or a compiled plan - not both.");
     }
 
-    if (StringUtils.isAllBlank(sqlFile, planFile)) {
+    if (StringUtils.isBlank(sqlFile) && StringUtils.isBlank(planFile)) {
       throw new IllegalArgumentException(
           "Invalid input. Please provide one of the following combinations: 1. A single SQL file (--sqlfile) 2. A plan JSON file (--planfile)");
     }

--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/EnvVarResolver.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/EnvVarResolver.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;

--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/SqlExecutor.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/SqlExecutor.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;

--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/StringUtils.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/StringUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2025 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner;
+
+/** Utility class for string operations. */
+final class StringUtils {
+
+  static boolean isBlank(String str) {
+    return str == null || str.trim().isEmpty();
+  }
+
+  static boolean isNotBlank(String str) {
+    return !isBlank(str);
+  }
+}


### PR DESCRIPTION
Since by default Flink uses child-first class-loading, if a user ships a wrong version of a 3rd party dep we use in the common deployment code, it may break before deploy, so we should only use Flink-specific deps and picocli in any `flink-sql-runner` module class.