### PR TITLE
Use Iceberg AWS bundle instead of standalone AWS SDK JARs

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -72,6 +72,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Will be shipped as Flink lib -->
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-aws-bundle</artifactId>
+      <version>${iceberg.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Required for Iceberg to work -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -88,28 +96,6 @@
           <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- AWS SDK v2 required for Iceberg S3FileIO -->
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>s3</artifactId>
-      <version>${aws.sdk.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>sts</artifactId>
-      <version>${aws.sdk.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>url-connection-client</artifactId>
-      <version>${aws.sdk.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Add logging framework, to produce console output when running in the IDE. -->
@@ -462,7 +448,7 @@
         </executions>
       </plugin>
 
-      <!-- Copying UDF/SystemFunction JARs -->
+      <!-- Copying S3, Iceberg, UDF JARs -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -493,6 +479,18 @@
             </configuration>
           </execution>
           <execution>
+            <id>copy-iceberg-aws-bundle</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <includeGroupIds>org.apache.iceberg</includeGroupIds>
+              <includeArtifactIds>iceberg-aws-bundle</includeArtifactIds>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
             <id>copy-hdfs-client-for-iceberg</id>
             <goals>
               <goal>copy-dependencies</goal>
@@ -502,17 +500,6 @@
               <includeGroupIds>org.apache.hadoop</includeGroupIds>
               <includeArtifactIds>hadoop-hdfs-client</includeArtifactIds>
               <outputDirectory>${project.build.directory}</outputDirectory>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-aws-sdk-for-iceberg</id>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <includeGroupIds>software.amazon.awssdk</includeGroupIds>
-              <outputDirectory>${project.build.directory}/aws-sdk</outputDirectory>
             </configuration>
           </execution>
           <execution>

--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /opt/flink/plugins/flink-sql-runner
 COPY flink-s3-fs-hadoop-*.jar /opt/flink/lib
 COPY hadoop-hdfs-client-*.jar /opt/flink/lib
 COPY iceberg-flink-runtime-*.jar /opt/flink/lib
-COPY aws-sdk/*.jar /opt/flink/lib/
+COPY iceberg-aws-bundle-*.jar /opt/flink/lib
 COPY stdlib-utils-*.jar /opt/flink/lib
 COPY flink-sql-runner.uber.jar /opt/flink/plugins/flink-sql-runner
 COPY entrypoint.sh /entrypoint.sh

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
     <assertj.version>3.27.6</assertj.version>
     <auto.service.version>1.1.1</auto.service.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <aws.sdk.version>2.36.2</aws.sdk.version>
     <commons-exec.version>1.5.0</commons-exec.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <feign.version>13.5</feign.version>


### PR DESCRIPTION
Currently we do not ship the necessry dependencies for AWS Glue. Using the Iceberg bundle makes sure everything Iceberg may expect will be available.