### PR TITLE
Add --host parameter to CLI for Flink 2.x compatibility

### DIFF
--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/CliRunner.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/CliRunner.java
@@ -63,6 +63,12 @@ public class CliRunner extends BaseRunner {
         description = "Path to UDFs.")
     private String udfPath;
 
+    @Option(
+        names = {"--host"},
+        description = "Host address passed by Flink 2.x application mode (accepted but not used).",
+        hidden = true)
+    private String host;
+
     @Override
     public Void call() {
       return null;


### PR DESCRIPTION
## Summary

- Adds `--host` parameter to `CliRunner` CLI to accept (and ignore) the host argument passed by Flink 2.x standalone application mode

## Problem

In Flink 2.x, the `docker-entrypoint.sh` script for `standalone-job` mode forwards `--host <IP>` to the user's main class. This is a behavior change from Flink 1.x and causes the flink-sql-runner to fail with:

```
Unknown options: '--host', '10.11.35.147'
```

## Solution

Added `--host` as a hidden optional parameter that gets accepted but not used, allowing compatibility with Flink 2.x Kubernetes Operator deployments.

Fixes #250