### PR TITLE
Ship kafka-clients to Flink lib for MSK IAM auth support

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -86,6 +86,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.clients.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Required for Iceberg to work -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -498,6 +505,18 @@
             <configuration>
               <includeGroupIds>software.amazon.msk</includeGroupIds>
               <includeArtifactIds>aws-msk-iam-auth</includeArtifactIds>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-kafka-clients</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <includeGroupIds>org.apache.kafka</includeGroupIds>
+              <includeArtifactIds>kafka-clients</includeArtifactIds>
               <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
           </execution>

--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -19,6 +19,7 @@ FROM apache/flink:${flink-base-image}
 RUN mkdir -p /opt/flink/plugins/flink-sql-runner
 
 COPY aws-msk-iam-auth-*.jar /opt/flink/lib
+COPY kafka-clients-*.jar /opt/flink/lib
 COPY flink-s3-fs-hadoop-*.jar /opt/flink/lib
 COPY hadoop-common-*.jar /opt/flink/lib
 COPY hadoop-hdfs-client-*.jar /opt/flink/lib

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <auto.service.version>1.1.1</auto.service.version>
     <awaitility.version>4.3.0</awaitility.version>
     <aws-msk-iam-auth.version>2.3.5</aws-msk-iam-auth.version>
+    <kafka.clients.version>3.9.1</kafka.clients.version>
     <commons-exec.version>1.6.0</commons-exec.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <feign.version>13.5</feign.version>


### PR DESCRIPTION
## Summary

Adds `kafka-clients` JAR to Flink's lib directory to fix `NoClassDefFoundError: org/apache/kafka/common/security/auth/AuthenticateCallbackHandler` when using MSK IAM authentication.

## Problem

When connecting to MSK with IAM authentication, the `aws-msk-iam-auth` library requires Kafka's authentication interfaces which are defined in `kafka-clients`. While `kafka-clients` is included as a transitive dependency in the shaded uber JAR, it's not accessible from Flink's lib classloader where `aws-msk-iam-auth` is loaded.

## Solution

- Added `kafka-clients` (3.9.1) as a provided dependency
- Added maven-dependency-plugin execution to copy the JAR to target
- Updated Dockerfile to include `kafka-clients-*.jar` in `/opt/flink/lib`

## Test Plan

- Built project successfully with `mvn clean install -Pfast`
- Verified `kafka-clients-3.9.1.jar` is copied to target directory