### PR TITLE
feat: Add officially released Flink 2.x compatible CDC connectors

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -214,6 +214,24 @@
       <version>${http.conn.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-sql-connector-mysql-cdc</artifactId>
+      <version>${flink.cdc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-sql-connector-postgres-cdc</artifactId>
+      <version>${flink.cdc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-sql-connector-sqlserver-cdc</artifactId>
+      <version>${flink.cdc.version}</version>
+    </dependency>
+
     <!-- Flink Formats -->
     <dependency>
       <groupId>org.apache.flink</groupId>
@@ -635,31 +653,6 @@
             <configuration>
               <includeArtifactIds>org.jacoco.agent</includeArtifactIds>
               <outputDirectory>${project.build.directory}</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-existing-jars</id>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/artifact</directory>
-                  <includes>
-                    <include>*.jar</include>
-                  </includes>
-                </resource>
-              </resources>
             </configuration>
           </execution>
         </executions>

--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -26,7 +26,6 @@ COPY hadoop-mapreduce-client-core-*.jar /opt/flink/lib
 COPY iceberg-flink-runtime-*.jar /opt/flink/lib
 COPY iceberg-aws-bundle-*.jar /opt/flink/lib
 COPY stdlib-utils-*.jar /opt/flink/lib
-COPY flink-sql-connector-sqlserver-cdc-sqrl.jar /opt/flink/lib
 COPY flink-sql-runner.uber.jar /opt/flink/plugins/flink-sql-runner
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
     <flink.version>2.2.0</flink.version>
     <flink.version.label>flink-2.2</flink.version.label>
     <flink-base-image>${flink.version}-java17</flink-base-image>
+    <flink.cdc.version>3.6.0-2.2</flink.cdc.version>
     <http.conn.version>0.25.0</http.conn.version>
     <jdbc.conn.version>4.0.0-2.0</jdbc.conn.version>
     <kafka.conn.version>4.0.1-2.0</kafka.conn.version>
@@ -129,7 +130,6 @@
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <spotless-maven-plugin>3.1.0</spotless-maven-plugin>
@@ -341,12 +341,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>${maven-resources-plugin.version}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
## Key Changes
- Remove custom patched SQL Server CDC JAR
- Include `Postgres`, `MySQL`, and `SQL Server` CDC connectors for now