### PR TITLE
feat: Add `metronome` source implementation

### DIFF
--- a/connectors/datagen-connectors/pom.xml
+++ b/connectors/datagen-connectors/pom.xml
@@ -35,5 +35,19 @@
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-planner_2.12</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-test-utils</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/connectors/datagen-connectors/pom.xml
+++ b/connectors/datagen-connectors/pom.xml
@@ -21,33 +21,19 @@
 
   <parent>
     <groupId>com.datasqrl.flinkrunner</groupId>
-    <artifactId>flink-sql-runner-parent</artifactId>
+    <artifactId>connectors</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>connectors</artifactId>
-  <packaging>pom</packaging>
-  <name>Connectors</name>
-
-  <modules>
-    <module>datagen-connectors</module>
-    <module>kafka-safe-connector</module>
-    <module>postgresql-connector</module>
-  </modules>
+  <artifactId>datagen-connectors</artifactId>
+  <name>Datagen Connectors</name>
 
   <dependencies>
-    <!-- Provided -->
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-base</artifactId>
+      <artifactId>flink-table-api-java-bridge</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
-    </dependency>
-
-    <!-- Compile -->
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeDynamicTableSourceFactory.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeDynamicTableSourceFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome;
+
+import com.google.auto.service.AutoService;
+import java.util.Set;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+/** Dynamic table factory for the {@code metronome} connector. */
+@AutoService(Factory.class)
+public class MetronomeDynamicTableSourceFactory implements DynamicTableSourceFactory {
+
+  public static final String IDENTIFIER = "metronome";
+
+  @Override
+  public DynamicTableSource createDynamicTableSource(Context context) {
+    FactoryUtil.createTableFactoryHelper(this, context).validate();
+
+    var rowDataType = context.getPhysicalRowDataType();
+    validateSchema(rowDataType);
+
+    return new MetronomeTableSource(rowDataType);
+  }
+
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    return Set.of();
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    return Set.of();
+  }
+
+  private static void validateSchema(DataType rowDataType) {
+    var fieldDataTypes = DataType.getFieldDataTypes(rowDataType);
+    if (fieldDataTypes.size() != 2) {
+      throw new ValidationException(
+          "Metronome source expects exactly two physical columns: BIGINT sequence number and timestamp.");
+    }
+
+    var firstField = fieldDataTypes.get(0).getLogicalType().getTypeRoot();
+    var secondField = fieldDataTypes.get(1).getLogicalType().getTypeRoot();
+
+    if (firstField != LogicalTypeRoot.BIGINT) {
+      throw new ValidationException("Metronome source first column must be BIGINT.");
+    }
+
+    if (secondField != LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+        && secondField != LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+      throw new ValidationException(
+          "Metronome source second column must be TIMESTAMP or TIMESTAMP_LTZ.");
+    }
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeReader.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeReader.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+/** Source reader that emits due metronome rows and snapshots sequence progress in its split. */
+public class MetronomeReader implements SourceReader<RowData, MetronomeSplit> {
+
+  public static final long UNINITIALIZED = Long.MIN_VALUE;
+
+  private final SourceReaderContext readerContext;
+  @Nullable private final Long numberOfRows;
+  private final ScheduledExecutorService availabilityExecutor;
+
+  private CompletableFuture<Void> availability;
+  private boolean noMoreSplits;
+  private boolean closed;
+  private boolean splitAssigned;
+  private long lastEmittedNumber;
+  private long startTimestampSec;
+
+  public MetronomeReader(SourceReaderContext readerContext, @Nullable Long numberOfRows) {
+    this.readerContext = readerContext;
+    this.numberOfRows = numberOfRows;
+    this.availability = new CompletableFuture<>();
+    this.availabilityExecutor =
+        Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("metronome-source"));
+    this.lastEmittedNumber = 0L;
+    this.startTimestampSec = UNINITIALIZED;
+  }
+
+  @Override
+  public void start() {
+    readerContext.sendSplitRequest();
+  }
+
+  /**
+   * Emits the next due metronome row, or schedules the reader to become available at the next
+   * second boundary.
+   *
+   * <p>The emitted sequence number is derived from wall-clock epoch seconds relative to the first
+   * observed start second. If the reader wakes up late, repeated calls emit all missing sequence
+   * numbers with their intended event timestamps until the source catches up.
+   */
+  @Override
+  public InputStatus pollNext(ReaderOutput<RowData> output) {
+    if (closed) {
+      return InputStatus.END_OF_INPUT;
+    }
+
+    if (!splitAssigned) {
+      return noMoreSplits ? InputStatus.END_OF_INPUT : InputStatus.NOTHING_AVAILABLE;
+    }
+
+    long currentTimestampSec = currentTimestampSec();
+    if (startTimestampSec == UNINITIALIZED) {
+      startTimestampSec = currentTimestampSec;
+    }
+
+    long targetNumber = currentTimestampSec - startTimestampSec;
+    if (numberOfRows != null) {
+      targetNumber = Math.min(targetNumber, numberOfRows);
+    }
+
+    if (lastEmittedNumber < targetNumber) {
+      long nextNumber = lastEmittedNumber + 1;
+      long eventTimestampSec = startTimestampSec + nextNumber;
+      long eventTimestampMillis = eventTimestampSec * 1000L;
+      var row =
+          GenericRowData.of(
+              nextNumber, TimestampData.fromInstant(Instant.ofEpochSecond(eventTimestampSec)));
+      lastEmittedNumber = nextNumber;
+      output.collect(row, eventTimestampMillis);
+
+      return lastEmittedNumber < targetNumber ? InputStatus.MORE_AVAILABLE : nextStatus();
+    }
+
+    return nextStatus();
+  }
+
+  /**
+   * Snapshots the assigned split as the reader's progress state.
+   *
+   * <p>The split carries the only source progress that must survive failover: the last emitted
+   * sequence number and the source's fixed start epoch second.
+   */
+  @Override
+  public List<MetronomeSplit> snapshotState(long checkpointId) {
+    if (!splitAssigned || closed || (numberOfRows != null && lastEmittedNumber >= numberOfRows)) {
+      return List.of();
+    }
+
+    return List.of(new MetronomeSplit(lastEmittedNumber, startTimestampSec));
+  }
+
+  /** Returns the current availability future used by the Flink runtime to avoid busy polling. */
+  @Override
+  public CompletableFuture<Void> isAvailable() {
+    return availability;
+  }
+
+  /** Restores progress from the assigned split and makes the reader immediately pollable. */
+  @Override
+  public void addSplits(List<MetronomeSplit> splits) {
+    for (var split : splits) {
+      lastEmittedNumber = split.lastEmittedNumber();
+      startTimestampSec = split.startTimestampSec();
+      splitAssigned = true;
+      break;
+    }
+    completeAvailability();
+  }
+
+  @Override
+  public void notifyNoMoreSplits() {
+    noMoreSplits = true;
+    completeAvailability();
+  }
+
+  /** Closes the reader and wakes any runtime caller blocked on the current availability future. */
+  @Override
+  public void close() {
+    closed = true;
+    availabilityExecutor.shutdownNow();
+    completeAvailability();
+  }
+
+  /**
+   * Determines the next source status after a poll cycle.
+   *
+   * <p>The source ends when bounded output is exhausted or the sequence reaches {@link
+   * Long#MAX_VALUE}. Otherwise, it replaces the availability future and schedules it for the next
+   * epoch-second boundary.
+   */
+  private InputStatus nextStatus() {
+    if (lastEmittedNumber == Long.MAX_VALUE
+        || (numberOfRows != null && lastEmittedNumber >= numberOfRows)) {
+      closed = true;
+      return InputStatus.END_OF_INPUT;
+    }
+
+    if (noMoreSplits && startTimestampSec == UNINITIALIZED) {
+      return InputStatus.END_OF_INPUT;
+    }
+
+    availability = new CompletableFuture<>();
+    scheduleAvailability(nanosUntilNextSecond());
+
+    return InputStatus.NOTHING_AVAILABLE;
+  }
+
+  private void completeAvailability() {
+    availability.complete(null);
+  }
+
+  /** Schedules completion of the current availability future using nanosecond delay precision. */
+  private void scheduleAvailability(long delayNanos) {
+    if (!closed) {
+      availabilityExecutor.schedule(this::completeAvailability, delayNanos, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /** Returns the current wall-clock epoch second used for sequence catch-up calculations. */
+  private static long currentTimestampSec() {
+    return Instant.now().getEpochSecond();
+  }
+
+  /** Returns the remaining nanoseconds until the next wall-clock epoch-second boundary. */
+  private static long nanosUntilNextSecond() {
+    int currentNano = Instant.now().getNano();
+
+    return TimeUnit.SECONDS.toNanos(1L) - currentNano;
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeSource.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeSource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator.MetronomeEnumerator;
+import com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator.MetronomeEnumeratorState;
+import com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator.MetronomeEnumeratorStateSerializer;
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplitSerializer;
+import java.io.Serial;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.table.data.RowData;
+
+/** Source that produces a single global metronome sequence with event-time timestamps. */
+@AllArgsConstructor
+public class MetronomeSource implements Source<RowData, MetronomeSplit, MetronomeEnumeratorState> {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  @Nullable private final Long numberOfRows;
+
+  public MetronomeSource() {
+    this(null);
+  }
+
+  @Override
+  public Boundedness getBoundedness() {
+    return numberOfRows == null ? Boundedness.CONTINUOUS_UNBOUNDED : Boundedness.BOUNDED;
+  }
+
+  @Override
+  public SourceReader<RowData, MetronomeSplit> createReader(SourceReaderContext readerContext) {
+    return new MetronomeReader(readerContext, numberOfRows);
+  }
+
+  @Override
+  public SplitEnumerator<MetronomeSplit, MetronomeEnumeratorState> createEnumerator(
+      SplitEnumeratorContext<MetronomeSplit> enumContext) {
+
+    return new MetronomeEnumerator(enumContext, MetronomeEnumeratorState.unassigned());
+  }
+
+  @Override
+  public SplitEnumerator<MetronomeSplit, MetronomeEnumeratorState> restoreEnumerator(
+      SplitEnumeratorContext<MetronomeSplit> enumContext,
+      MetronomeEnumeratorState checkpointState) {
+
+    return new MetronomeEnumerator(enumContext, checkpointState);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<MetronomeSplit> getSplitSerializer() {
+    return new MetronomeSplitSerializer();
+  }
+
+  @Override
+  public SimpleVersionedSerializer<MetronomeEnumeratorState> getEnumeratorCheckpointSerializer() {
+    return new MetronomeEnumeratorStateSerializer();
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeTableSource.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeTableSource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome;
+
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.types.DataType;
+
+/** Table source adapter that exposes the metronome source to Flink SQL. */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MetronomeTableSource implements ScanTableSource, SupportsLimitPushDown {
+
+  private static final int SOURCE_PARALLELISM = 1;
+
+  private final DataType rowDataType;
+
+  @Nullable private Long numberOfRows;
+
+  public MetronomeTableSource(DataType rowDataType) {
+    this(rowDataType, null);
+  }
+
+  @Override
+  public ChangelogMode getChangelogMode() {
+    return ChangelogMode.insertOnly();
+  }
+
+  @Override
+  public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+    return SourceProvider.of(new MetronomeSource(numberOfRows), SOURCE_PARALLELISM);
+  }
+
+  @Override
+  public DynamicTableSource copy() {
+    return new MetronomeTableSource(rowDataType, numberOfRows);
+  }
+
+  @Override
+  public String asSummaryString() {
+    return "MetronomeSource";
+  }
+
+  @Override
+  public void applyLimit(long limit) {
+    this.numberOfRows = limit;
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumerator.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import java.util.List;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+
+/**
+ * Enumerator that owns the single metronome split and reassigns pending split state on recovery.
+ */
+@AllArgsConstructor
+public final class MetronomeEnumerator
+    implements SplitEnumerator<MetronomeSplit, MetronomeEnumeratorState> {
+
+  private final SplitEnumeratorContext<MetronomeSplit> context;
+  private MetronomeEnumeratorState state;
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+    if (state.getPendingSplit() != null) {
+      context.assignSplit(state.getPendingSplit(), subtaskId);
+      state = MetronomeEnumeratorState.assigned();
+
+    } else if (!state.isAssigned()) {
+      context.assignSplit(MetronomeSplit.initial(), subtaskId);
+      state = MetronomeEnumeratorState.assigned();
+
+    } else {
+      context.signalNoMoreSplits(subtaskId);
+    }
+  }
+
+  @Override
+  public void addSplitsBack(List<MetronomeSplit> splits, int subtaskId) {
+    if (!splits.isEmpty()) {
+      state = MetronomeEnumeratorState.pending(splits.get(0));
+    }
+  }
+
+  @Override
+  public void addReader(int subtaskId) {}
+
+  @Override
+  public MetronomeEnumeratorState snapshotState(long checkpointId) {
+    return state;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumeratorState.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumeratorState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Checkpointed enumerator state for initial assignment and pending split reassignment. */
+@Getter
+@RequiredArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class MetronomeEnumeratorState {
+
+  private final boolean assigned;
+  @Nullable private final MetronomeSplit pendingSplit;
+
+  public static MetronomeEnumeratorState of(boolean assigned) {
+    return assigned ? assigned() : unassigned();
+  }
+
+  public static MetronomeEnumeratorState assigned() {
+    return new MetronomeEnumeratorState(true, null);
+  }
+
+  public static MetronomeEnumeratorState unassigned() {
+    return new MetronomeEnumeratorState(false, null);
+  }
+
+  public static MetronomeEnumeratorState pending(MetronomeSplit split) {
+    return new MetronomeEnumeratorState(false, split);
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumeratorStateSerializer.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/enumerator/MetronomeEnumeratorStateSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome.enumerator;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import java.io.IOException;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+/** Serializer for enumerator checkpoint state. */
+public final class MetronomeEnumeratorStateSerializer
+    implements SimpleVersionedSerializer<MetronomeEnumeratorState> {
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+
+  @Override
+  public byte[] serialize(MetronomeEnumeratorState state) throws IOException {
+    var out = new DataOutputSerializer(18);
+    var pendingSplit = state.getPendingSplit();
+
+    out.writeBoolean(state.isAssigned());
+    out.writeBoolean(pendingSplit != null);
+
+    if (pendingSplit != null) {
+      out.writeLong(pendingSplit.lastEmittedNumber());
+      out.writeLong(pendingSplit.startTimestampSec());
+    }
+
+    return out.getCopyOfBuffer();
+  }
+
+  @Override
+  public MetronomeEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
+    var in = new DataInputDeserializer(serialized);
+
+    boolean assigned = in.readBoolean();
+    boolean hasPendingSplit = in.readBoolean();
+
+    return hasPendingSplit
+        ? MetronomeEnumeratorState.pending(new MetronomeSplit(in.readLong(), in.readLong()))
+        : MetronomeEnumeratorState.of(assigned);
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/split/MetronomeSplit.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/split/MetronomeSplit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome.split;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.MetronomeReader;
+import org.apache.flink.api.connector.source.SourceSplit;
+
+/** Single source split carrying metronome reader progress across checkpoints and recovery. */
+public record MetronomeSplit(long lastEmittedNumber, long startTimestampSec)
+    implements SourceSplit {
+
+  public static MetronomeSplit initial() {
+    return new MetronomeSplit(0L, MetronomeReader.UNINITIALIZED);
+  }
+
+  @Override
+  public String splitId() {
+    return "metronome";
+  }
+}

--- a/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/split/MetronomeSplitSerializer.java
+++ b/connectors/datagen-connectors/src/main/java/com/datasqrl/flinkrunner/connector/datagen/metronome/split/MetronomeSplitSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome.split;
+
+import java.io.IOException;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+/** Serializer for the metronome split progress state. */
+public final class MetronomeSplitSerializer implements SimpleVersionedSerializer<MetronomeSplit> {
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+
+  @Override
+  public byte[] serialize(MetronomeSplit split) throws IOException {
+    var out = new DataOutputSerializer(16);
+    out.writeLong(split.lastEmittedNumber());
+    out.writeLong(split.startTimestampSec());
+
+    return out.getCopyOfBuffer();
+  }
+
+  @Override
+  public MetronomeSplit deserialize(int version, byte[] serialized) throws IOException {
+    var in = new DataInputDeserializer(serialized);
+
+    return new MetronomeSplit(in.readLong(), in.readLong());
+  }
+}

--- a/connectors/datagen-connectors/src/test/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeSourceIT.java
+++ b/connectors/datagen-connectors/src/test/java/com/datasqrl/flinkrunner/connector/datagen/metronome/MetronomeSourceIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2026 DataSQRL (contact@datasqrl.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datasqrl.flinkrunner.connector.datagen.metronome;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datasqrl.flinkrunner.connector.datagen.metronome.split.MetronomeSplit;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.UserCodeClassLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Integration tests for the metronome SQL connector. */
+@ExtendWith(MiniClusterExtension.class)
+class MetronomeSourceIT { // extends TableITCaseBase {
+
+  private TableEnvironment tEnv;
+
+  @BeforeEach
+  void beforeEach() {
+    tEnv = TableEnvironmentImpl.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+    tEnv.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+  }
+
+  @Test
+  @Timeout(30)
+  void happyPathEmitsMonotonicSequence() throws Exception {
+    tEnv.executeSql(
+        """
+            CREATE TABLE metronome_source (
+              num BIGINT,
+              ts TIMESTAMP_LTZ(3),
+              WATERMARK FOR ts AS ts
+            ) WITH (
+              'connector' = 'metronome'
+            )""");
+
+    assertThat(collectRows("SELECT num FROM metronome_source", 3))
+        .containsExactly(Row.of(1L), Row.of(2L), Row.of(3L));
+  }
+
+  @Test
+  void restoresReaderProgressFromCheckpointedSplit() {
+    long startTimestampSec = Instant.now().getEpochSecond() - 3L;
+    var reader = new MetronomeReader(unusedReaderContext(), 3L);
+    var output = new CollectingReaderOutput();
+
+    try {
+      reader.addSplits(List.of(new MetronomeSplit(1L, startTimestampSec)));
+
+      assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+      assertThat(output.numbers()).containsExactly(2L);
+      assertThat(reader.snapshotState(1L))
+          .containsExactly(new MetronomeSplit(2L, startTimestampSec));
+    } finally {
+      reader.close();
+    }
+  }
+
+  private List<Row> collectRows(String sql, int rowCount) throws Exception {
+    List<Row> rows = new ArrayList<>();
+    try (CloseableIterator<Row> iterator = tEnv.executeSql(sql).collect()) {
+      while (rows.size() < rowCount) {
+        rows.add(iterator.next());
+      }
+    }
+    return rows;
+  }
+
+  private static SourceReaderContext unusedReaderContext() {
+    return new SourceReaderContext() {
+      @Override
+      public SourceReaderMetricGroup metricGroup() {
+        return null;
+      }
+
+      @Override
+      public Configuration getConfiguration() {
+        return new Configuration();
+      }
+
+      @Override
+      public String getLocalHostName() {
+        return "localhost";
+      }
+
+      @Override
+      public int getIndexOfSubtask() {
+        return 0;
+      }
+
+      @Override
+      public void sendSplitRequest() {}
+
+      @Override
+      public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {}
+
+      @Override
+      public UserCodeClassLoader getUserCodeClassLoader() {
+        return null;
+      }
+    };
+  }
+
+  private static final class CollectingReaderOutput implements ReaderOutput<RowData> {
+
+    private final List<RowData> rows = new ArrayList<>();
+
+    @Override
+    public void collect(RowData record) {
+      rows.add(record);
+    }
+
+    @Override
+    public void collect(RowData record, long timestamp) {
+      rows.add(record);
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {}
+
+    @Override
+    public void markIdle() {}
+
+    @Override
+    public void markActive() {}
+
+    @Override
+    public SourceOutput<RowData> createOutputForSplit(String splitId) {
+      return this;
+    }
+
+    @Override
+    public void releaseOutputForSplit(String splitId) {}
+
+    private List<Long> numbers() {
+      return rows.stream().map(row -> row.getLong(0)).toList();
+    }
+  }
+}

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -129,6 +129,12 @@
     <!-- Custom Connectors -->
     <dependency>
       <groupId>com.datasqrl.flinkrunner</groupId>
+      <artifactId>datagen-connectors</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datasqrl.flinkrunner</groupId>
       <artifactId>kafka-safe-connector</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
## Key Changes
- Added a new `metronome` connector that emits a monotonically increasing `BIGINT` sequence  per second based on a wall-clock timestamp column
- Parallelism is forced to 1 so the metronome acts as a single global clock source
- Emits catch-up records when delayed by comparing current epoch seconds against the persisted start epoch second and last emitted sequence number
- Uses intended event timestamps for catch-up records, so delayed emissions still map to the correct event-time seconds
- State is carried through `MetronomeSplit`, preserving `lastEmittedNumber` and `startTimestampSec`
- `MetronomeEnumeratorState` also tracks any pending split, so returned splits are reassigned without losing progress
- Supports limit pushdown by creating a bounded runtime source when `LIMIT` is pushed into the table source
- Added schema validation requiring exactly two physical columns: `BIGINT` and `TIMESTAMP`/`TIMESTAMP_LTZ`
