### PR TITLE
chore: Include `flink-metrics-dropwizard` that was removed from the Iceberg fat JAR

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -261,6 +261,13 @@
       <version>${aws-msk-iam-auth.version}</version>
     </dependency>
 
+    <!-- Required for Iceberg file-size histogram metrics -->
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-metrics-dropwizard</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+
     <!-- Runtime -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
This dep got removed from the Iceberg fat JAR starting with 1.11.0. Without this dep, we'll get warnings in case of an iceberg flink job like:
```
2026-07-06 12:46:33,738 WARN  org.apache.iceberg.flink.sink.IcebergStreamWriterMetrics     [] - Cannot load Dropwizard metrics; is org.apache.flink:flink-metrics-dropwizard on the classpath?
java.lang.ClassNotFoundException: Cannot find class; alternatives: com.codahale.metrics.Reservoir
	at org.apache.iceberg.common.DynClasses$Builder.buildChecked(DynClasses.java:98) ~[iceberg-flink-runtime-2.1-1.11.0.jar:?]
	at org.apache.iceberg.flink.sink.IcebergStreamWriterMetrics.loadDropwizardCtors(IcebergStreamWriterMetrics.java:134) ~[iceberg-flink-runtime-2.1-1.11.0.jar:?]
	at org.apache.iceberg.flink.sink.IcebergStreamWriterMetrics.<clinit>(IcebergStreamWriterMetrics.java:46) ~[iceberg-flink-runtime-2.1-1.11.0.jar:?]
	at org.apache.iceberg.flink.sink.IcebergSink.createWriter(IcebergSink.java:228) ~[iceberg-flink-runtime-2.1-1.11.0.jar:?]
	at org.apache.flink.streaming.runtime.operators.sink.StatelessSinkWriterStateHandler.createWriter(StatelessSinkWriterStateHandler.java:39) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperator.initializeState(SinkWriterOperator.java:171) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.api.operators.StreamOperatorStateHandler.initializeOperatorState(StreamOperatorStateHandler.java:142) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.api.operators.AbstractStreamOperator.initializeState(AbstractStreamOperator.java:308) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:106) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreStateAndGates(StreamTask.java:866) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$restoreInternal$5(StreamTask.java:820) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:820) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:779) ~[flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:973) [flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:945) [flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:760) [flink-dist-2.2.1.jar:2.2.1]
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:569) [flink-dist-2.2.1.jar:2.2.1]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```
It doesn't disrupt anything regarding the deployment, but without it, iceberg file-size histogram metrics won't be collected.