### PR TITLE
Resolve env-var placeholders in Flink config.yaml

### DIFF
--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
@@ -91,8 +91,7 @@ abstract class BaseRunner {
     var conf = new Configuration();
     if (StringUtils.isNotBlank(configDir)) {
       log.info("Loading Flink configuration from '{}'", configDir);
-      conf = GlobalConfiguration.loadConfiguration(configDir);
-      resolveEnvVars(conf);
+      conf = resolveEnvVars(GlobalConfiguration.loadConfiguration(configDir));
     }
 
     // Do not overwrite runtime given in YAML
@@ -103,15 +102,10 @@ abstract class BaseRunner {
     return conf;
   }
 
-  /**
-   * Resolves {@code ${VAR}} placeholders in Flink configuration values from the environment, the
-   * same mechanism already applied to the SQL script and compiled plan. Lets secrets (e.g. the
-   * Iceberg maintenance lock JDBC credentials) be injected via env vars instead of landing in the
-   * plaintext config.yaml ConfigMap. {@link Configuration#toMap()} returns a copy, so mutating
-   * {@code conf} while iterating it is safe.
-   */
-  private void resolveEnvVars(Configuration conf) {
-    conf.toMap()
+  private Configuration resolveEnvVars(Configuration source) {
+    var conf = new Configuration(source);
+    source
+        .toMap()
         .forEach(
             (key, value) -> {
               var resolved = resolver.resolve(value);
@@ -119,6 +113,7 @@ abstract class BaseRunner {
                 conf.setString(key, resolved);
               }
             });
+    return conf;
   }
 
   static String readTextFile(String path) throws IOException {

--- a/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
+++ b/flink-sql-runner/src/main/java/com/datasqrl/flinkrunner/BaseRunner.java
@@ -92,6 +92,7 @@ abstract class BaseRunner {
     if (StringUtils.isNotBlank(configDir)) {
       log.info("Loading Flink configuration from '{}'", configDir);
       conf = GlobalConfiguration.loadConfiguration(configDir);
+      resolveEnvVars(conf);
     }
 
     // Do not overwrite runtime given in YAML
@@ -100,6 +101,24 @@ abstract class BaseRunner {
     }
 
     return conf;
+  }
+
+  /**
+   * Resolves {@code ${VAR}} placeholders in Flink configuration values from the environment, the
+   * same mechanism already applied to the SQL script and compiled plan. Lets secrets (e.g. the
+   * Iceberg maintenance lock JDBC credentials) be injected via env vars instead of landing in the
+   * plaintext config.yaml ConfigMap. {@link Configuration#toMap()} returns a copy, so mutating
+   * {@code conf} while iterating it is safe.
+   */
+  private void resolveEnvVars(Configuration conf) {
+    conf.toMap()
+        .forEach(
+            (key, value) -> {
+              var resolved = resolver.resolve(value);
+              if (!resolved.equals(value)) {
+                conf.setString(key, resolved);
+              }
+            });
   }
 
   static String readTextFile(String path) throws IOException {

--- a/flink-sql-runner/src/test/java/com/datasqrl/flinkrunner/CliRunnerTest.java
+++ b/flink-sql-runner/src/test/java/com/datasqrl/flinkrunner/CliRunnerTest.java
@@ -26,6 +26,7 @@ import com.datasqrl.flinkrunner.utils.EnvVarResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -170,5 +171,28 @@ class CliRunnerTest {
     // Assert
     assertThat(finalConf.keySet()).hasSize(1);
     assertThat(finalConf.get(ExecutionOptions.RUNTIME_MODE)).isEqualTo(mode);
+  }
+
+  @Test
+  void initConfiguration_shouldResolveEnvVarPlaceholdersInConfig() throws IOException {
+    // Arrange — a secret injected via env var, e.g. the Iceberg maintenance lock password
+    Path configFile = tempDir.resolve("config.yaml");
+    Files.writeString(
+        configFile,
+        "flink-maintenance.lock.jdbc.password: ${ICEBERG_LOCK_PASSWORD}\ndummy.key: literal");
+
+    var resolver =
+        EnvVarResolver.builder().envVars(Map.of("ICEBERG_LOCK_PASSWORD", "s3cr3t")).build();
+    var cliRunner =
+        new CliRunner(
+            RuntimeExecutionMode.STREAMING, resolver, null, null, tempDir.toString(), null);
+
+    // Act
+    var finalConf = cliRunner.initConfiguration();
+
+    // Assert
+    assertThat(finalConf.toMap())
+        .containsEntry("flink-maintenance.lock.jdbc.password", "s3cr3t")
+        .containsEntry("dummy.key", "literal");
   }
 }


### PR DESCRIPTION
## Summary

`BaseRunner.initConfiguration()` now runs the loaded `config.yaml` values through the existing `EnvVarResolver` (the same `${VAR}` mechanism already applied to the SQL script and compiled plan). This lets secrets be injected into Flink config via env vars instead of landing in the plaintext `config.yaml` ConfigMap.

Motivating use: Iceberg auto-maintenance wires a JDBC lock store whose credentials must not sit in a ConfigMap. cloud-compilation emits `flink-maintenance.lock.jdbc.user: ${ICEBERG_LOCK_USER}` / `...password: ${ICEBERG_LOCK_PASSWORD}` placeholders; the flink pod mounts them from the `iceberg-maintainance-locktable` secret, and this change resolves them at runtime.

`Configuration.toMap()` returns a copy, so mutating `conf` while iterating is safe. Values without `${...}` are untouched.

## Test

`CliRunnerTest.initConfiguration_shouldResolveEnvVarPlaceholdersInConfig` — asserts a `${VAR}` config value resolves from env and literals pass through. Full `CliRunnerTest` green (14/14, under Java 17).

## Related

- Pairs with cloud-compilation PR (branch `feat/iceberg-auto-maintenance`) which emits the config.
- Wayfinder ticket: DataSQRL/cloud-compilation-wayfinder#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
