### PR TITLE
Pin AWS SDK to 2.44.4 to match the copy bundled in iceberg-aws-bundle

### DIFF
--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -59,12 +59,6 @@ COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
 # noop.jar is an empty JAR. `flink run` requires a JAR positional argument, but the runner code
 # ships on the system classpath in lib/ (see bin/sql-runner), so this only satisfies the CLI.
-#
-# core-site.xml: Hadoop 3.3.4's default S3A credential chain omits WebIdentityTokenCredentialsProvider,
-# which IRSA needs on EKS (#290). The class named below is AWS SDK v1 and is deliberately the
-# *unrelocated* name -- flink-s3-fs-hadoop ships com/amazonaws/** unshaded, which is the only reason
-# this resolves. If that JAR is ever shaded, this silently stops applying and S3A IRSA breaks again.
-# Unrelated to MSK IAM auth, which uses the separate AWS SDK v2 (software.amazon.awssdk) chain.
 RUN echo 'UEsDBBQACAgIAG2UllwAAAAAAAAAAAAAAAAUAAQATUVUQS1JTkYvTUFOSUZFU1QuTUb+ygAA803My0xLLS7RDUstKs7Mz7NSMNQz4HIuSk0sSU3Rdaq0UkjLyczL1i0uzNEtKs3LSy3i4gIAUEsHCL/cUjU2AAAANAAAAFBLAQIUABQACAgIAG2Ully/3FI1NgAAADQAAAAUAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi9NQU5JRkVTVC5NRv7KAABQSwUGAAAAAAEAAQBGAAAAfAAAAAAA' | base64 -d > /opt/flink/noop.jar \
     && mkdir -p /opt/flink/hadoop-conf \
     && echo '<configuration><property><name>fs.s3a.aws.credentials.provider</name><value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value></property></configuration>' > /opt/flink/hadoop-conf/core-site.xml \

--- a/flink-sql-runner/src/main/docker/Dockerfile
+++ b/flink-sql-runner/src/main/docker/Dockerfile
@@ -57,6 +57,14 @@ COPY flink-sql-runner.uber.jar /opt/flink/lib/sql-runner.uber.jar
 COPY --chmod=755 sql-runner /opt/flink/bin/sql-runner
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
+# noop.jar is an empty JAR. `flink run` requires a JAR positional argument, but the runner code
+# ships on the system classpath in lib/ (see bin/sql-runner), so this only satisfies the CLI.
+#
+# core-site.xml: Hadoop 3.3.4's default S3A credential chain omits WebIdentityTokenCredentialsProvider,
+# which IRSA needs on EKS (#290). The class named below is AWS SDK v1 and is deliberately the
+# *unrelocated* name -- flink-s3-fs-hadoop ships com/amazonaws/** unshaded, which is the only reason
+# this resolves. If that JAR is ever shaded, this silently stops applying and S3A IRSA breaks again.
+# Unrelated to MSK IAM auth, which uses the separate AWS SDK v2 (software.amazon.awssdk) chain.
 RUN echo 'UEsDBBQACAgIAG2UllwAAAAAAAAAAAAAAAAUAAQATUVUQS1JTkYvTUFOSUZFU1QuTUb+ygAA803My0xLLS7RDUstKs7Mz7NSMNQz4HIuSk0sSU3Rdaq0UkjLyczL1i0uzNEtKs3LSy3i4gIAUEsHCL/cUjU2AAAANAAAAFBLAQIUABQACAgIAG2Ully/3FI1NgAAADQAAAAUAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi9NQU5JRkVTVC5NRv7KAABQSwUGAAAAAAEAAQBGAAAAfAAAAAAA' | base64 -d > /opt/flink/noop.jar \
     && mkdir -p /opt/flink/hadoop-conf \
     && echo '<configuration><property><name>fs.s3a.aws.credentials.provider</name><value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value></property></configuration>' > /opt/flink/hadoop-conf/core-site.xml \

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,9 @@
     <assertj.version>3.27.7</assertj.version>
     <auto.service.version>1.1.1</auto.service.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <aws-msk-iam-auth.version>2.3.7</aws-msk-iam-auth.version>
-    <!-- Must match the AWS SDK bundled inside iceberg-aws-bundle:${iceberg.version}; both land
-         unrelocated on the Flink system classpath, so a version skew is resolved first-wins.
-         Verify after an iceberg bump:
-           unzip -p iceberg-aws-bundle-<ver>.jar META-INF/maven/software.amazon.awssdk/sts/pom.properties -->
+    <!-- AWS SDK must be kept in sync with the version defined in "iceberg-aws-bundle" -->
     <awssdk.version>2.44.4</awssdk.version>
+    <aws-msk-iam-auth.version>2.3.7</aws-msk-iam-auth.version>
     <classgraph.version>4.8.186</classgraph.version>
     <commons-exec.version>1.6.0</commons-exec.version>
     <commons-math3.version>3.6.1</commons-math3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
     <auto.service.version>1.1.1</auto.service.version>
     <awaitility.version>4.3.0</awaitility.version>
     <aws-msk-iam-auth.version>2.3.7</aws-msk-iam-auth.version>
+    <!-- Must match the AWS SDK bundled inside iceberg-aws-bundle:${iceberg.version}; both land
+         unrelocated on the Flink system classpath, so a version skew is resolved first-wins.
+         Verify after an iceberg bump:
+           unzip -p iceberg-aws-bundle-<ver>.jar META-INF/maven/software.amazon.awssdk/sts/pom.properties -->
+    <awssdk.version>2.44.4</awssdk.version>
     <classgraph.version>4.8.186</classgraph.version>
     <commons-exec.version>1.6.0</commons-exec.version>
     <commons-math3.version>3.6.1</commons-math3.version>
@@ -161,6 +166,14 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Pins `software.amazon.awssdk` to **2.44.4** via the AWS SDK BOM, matching the SDK version bundled inside `iceberg-aws-bundle:1.11.0`.

Before this change the runner image shipped **two unrelocated copies of AWS SDK v2 at different versions** on the Flink *system* classpath:

| jar in `/opt/flink/lib` | AWS SDK | brings |
|---|---|---|
| `iceberg-aws-bundle-1.11.0.jar` | **2.44.4** | `auth`, `sts`, `aws-query-protocol`, `WebIdentityTokenFileCredentialsProvider`, … |
| `sql-runner.uber.jar` | **2.44.12** | same classes + `software.amazon.msk.auth.iam.*` + `kafka-clients` |

`2.44.12` arrives transitively through `aws-msk-iam-auth:2.3.7`:

```
software.amazon.msk:aws-msk-iam-auth:jar:2.3.7:compile
 +- software.amazon.awssdk:auth:jar:2.44.12:runtime
 +- software.amazon.awssdk:sts:jar:2.44.12:runtime
 \- ...
```

Iceberg's `2.44.4` is not a Maven edge — it is baked into the bundle jar — so Maven never sees the conflict and dependency convergence rules can't catch it.

Classpath order on a running TaskManager (from `/proc/1/cmdline`):

```
/opt/flink/lib/iceberg-aws-bundle-1.11.0.jar     <- wins
...
/opt/flink/lib/sql-runner.uber.jar               <- its 2.44.12 is dead weight
```

Class loading is first-wins, so **2.44.4 is what actually loads**, and the MSK IAM auth code — compiled against 2.44.12 — runs against 2.44.4 classes. Pinning makes the two copies **semantically identical**, so which one wins stops mattering. They are not byte-identical: the shade plugin renumbers the constant pool when it repackages, which flips some `ldc` to `ldc_w` and shifts every subsequent bytecode offset. Verified on the PR image by normalising pool indices out of `javap -c` output — same instructions, same operands, same targets.

## Why now — the bug under investigation

On `dev-signature`, TaskManagers running `0.10.5-flink-2.2` produced this during task teardown:

```
WARN  software.amazon.msk.auth.iam.internals.MSKCredentialProvider
      Exception loading credentials. Retry Attempts: 1
SdkClientException: Unable to load credentials from any of the providers in the chain ...
  WebIdentityTokenFileCredentialsProvider(): Unable to unmarshall response
    (Trying to access closed classloader...). Response Code: 200
```

The STS call returned **200** — IRSA is fine, this is not a permissions problem. The SDK simply could not unmarshal the response, and the failing code path is exactly `aws-query-protocol` / `AwsXmlErrorProtocolUnmarshaller`, one of the classes duplicated across the two jars.

Immediately before it, the same TaskManager logged:

```
ERROR org.apache.kafka.clients.producer.internals.Sender
      [Producer clientId=producer-34] Error in kafka producer I/O thread while aborting transaction when during closing:
IllegalStateException: Transactional method invoked on a non-transactional producer.
  at TransactionManager.ensureTransactional(TransactionManager.java:1149)
  at TransactionManager.beginAbort(TransactionManager.java:362)
  at Sender.run(Sender.java:273)
```

That second one is a separate, **pre-existing kafka-clients 4.2.0 issue**: `Sender.run()`'s force-close path calls `transactionManager.beginAbort()` guarded only on `transactionManager != null`. An idempotent-but-non-transactional producer (`enable.idempotence=true`, no `transactional.id`) still has a non-null `TransactionManager`, so `ensureTransactional()` throws. It fires only on `close(Duration.ZERO)`, which Flink issues when cancelling a task. **This PR does not address that** — tracked separately.

Both traces are teardown exhaust rather than the root cause, and the pod that produced them was later OOMKilled and evicted for exceeding its 20Gi `flink-local-data` EmptyDir limit. The duplicate-SDK skew is real regardless, and it is the cheapest of the three to remove — hence trying it first.

## Alternatives considered

Relocating `software.amazon.awssdk` in the uber jar's shade config is the more correct fix and would make the two copies genuinely independent. It is also a much larger change with its own risk around the SDK's reflective/`ServiceLoader` lookups. Trying the version pin first; if the skew turns out not to be the problem, shading is the next step.

Note that `org.apache.kafka.*` and `software.amazon.msk.*` are also unrelocated in the uber jar and carry the same collision risk — out of scope here.

## Verification

`mvn dependency:tree -Dincludes='software.amazon.awssdk:*'` now reports a single version:

```
software.amazon.awssdk:auth:jar:2.44.4:runtime
software.amazon.awssdk:sts:jar:2.44.4:runtime
software.amazon.awssdk:aws-query-protocol:jar:2.44.4:runtime
software.amazon.awssdk:apache-client:jar:2.44.4:runtime
```

`mvn clean test` passes across all 23 modules.

The pin carries a comment with the command to re-check the bundled version after any `iceberg.version` bump, since the two must move together.



## Also included: a comment on the S3A `core-site.xml` workaround

Second commit, docs only — no behaviour change.

While investigating, the `core-site.xml` added in #290 came up as a suspect. It is **not** related to the MSK failure: it configures `fs.s3a.aws.credentials.provider` with `com.amazonaws.auth.DefaultAWSCredentialsProviderChain`, which is AWS SDK **v1** and only affects the S3A filesystem. MSK IAM auth uses the separate SDK **v2** (`software.amazon.awssdk`) chain.

What did turn up is that the workaround is load-bearing in a non-obvious way: `flink-s3-fs-hadoop-2.2.1.jar` ships `com/amazonaws/**` **unrelocated**, and that is the only reason the unshaded class name in `core-site.xml` resolves at all. If that jar is ever shaded, the setting silently stops applying and S3A IRSA breaks again with no error pointing here.

Added a comment above the `RUN` recording that, plus a line explaining that `noop.jar` exists only to satisfy `flink run`'s required JAR positional argument (from #317). `docker build --check` passes.
